### PR TITLE
Allow aws_s3_bucket resource to configure static websites on s3

### DIFF
--- a/docs/examples/s3.rb
+++ b/docs/examples/s3.rb
@@ -1,0 +1,12 @@
+require 'chef/provisioning/aws_driver'
+with_driver 'aws'
+
+aws_s3_bucket 'aws-bucket' do
+  enable_website_hosting true
+  website_options :index_document => {
+    :suffix => "index.html"
+  },
+  :error_document => {
+    :key => "not_found.html"
+  }
+end

--- a/lib/chef/provider/aws_s3_bucket.rb
+++ b/lib/chef/provider/aws_s3_bucket.rb
@@ -7,6 +7,20 @@ class Chef::Provider::AwsS3Bucket < Chef::Provider::AwsProvider
       converge_by "Creating new S3 bucket #{fqn}" do
         bucket = s3.buckets.create(fqn)
         bucket.tags['Name'] = new_resource.name
+        if new_resource.enable_website_hosting
+          bucket.website_configuration = AWS::S3::WebsiteConfiguration.new(
+            new_resource.website_options)
+        end
+      end
+    elsif requires_modification?
+      converge_by "Modifying S3 Bucket #{fqn}" do
+        if existing_bucket.website_configuration == nil && new_resource.enable_website_hosting || 
+          existing_bucket.website_configuration != nil && new_resource.enable_website_hosting
+          existing_bucket.website_configuration = AWS::S3::WebsiteConfiguration.new(
+            new_resource.website_options)
+        else
+          existing_bucket.remove_website_configuration
+        end
       end
     end
 
@@ -29,13 +43,29 @@ class Chef::Provider::AwsS3Bucket < Chef::Provider::AwsProvider
     @existing_bucket ||= s3.buckets[fqn] if s3.buckets[fqn].exists?
   end
 
+  def requires_modification?
+    if existing_bucket.website_configuration == nil
+      new_resource.enable_website_hosting
+    else
+      !new_resource.enable_website_hosting ||
+        !compare_website_configuration
+    end
+  end
+
+  def compare_website_configuration
+    # This is incomplete, routing rules have many optional values, so its
+    # possible aws will put in default values for those which won't be in
+    # the requested config.
+    new_web_config = new_resource.website_options
+    current_web_config = existing_bucket.website_configuration.to_hash
+
+    current_web_config[:index_document] == new_web_config.fetch(:index_document, {}) &&
+      current_web_config[:error_document] == new_web_config.fetch(:error_document, {}) &&
+      current_web_config[:routing_rules] == new_web_config.fetch(:routing_rules, [])
+  end
+
   # Fully qualified bucket name (i.e resource_region unless otherwise specified)
   def id
-    new_resource.bucket_name
+    new_resource.bucket_name || new_resource.name
   end
-
-  def fqn
-    super.gsub('_', '-')
-  end
-
 end

--- a/lib/chef/resource/aws_s3_bucket.rb
+++ b/lib/chef/resource/aws_s3_bucket.rb
@@ -10,6 +10,8 @@ class Chef::Resource::AwsS3Bucket < Chef::Resource::AwsResource
 
   attribute :name, :kind_of => String, :name_attribute => true
   attribute :bucket_name, :kind_of => String
+  attribute :enable_website_hosting, :kind_of => [TrueClass, FalseClass], :default => false
+  attribute :website_options, :kind_of => Hash
 
   def initialize(*args)
     super


### PR DESCRIPTION
This change provides attributes to configure static websites on s3:

``` ruby
require 'chef/provisioning/aws_driver'
with_driver 'aws'

aws_s3_bucket 'preprod1.thechamberofunderstanding.com' do
  enable_website_hosting true
  website_options :index_document => {
    :suffix => "index.html"
  },
  :error_document => {
    :key => "not_found.html"
  }
end
```
