### PR TITLE
rename fog to aws

### DIFF
--- a/lib/chef/resource/aws_key_pair.rb
+++ b/lib/chef/resource/aws_key_pair.rb
@@ -1,7 +1,7 @@
 require 'chef/provisioning'
 
-class Chef::Resource::FogKeyPair < Chef::Resource::LWRPBase
-  self.resource_name = 'fog_key_pair'
+class Chef::Resource::AwsKeyPair < Chef::Resource::LWRPBase
+  self.resource_name = 'aws_key_pair'
 
   def initialize(*args)
     super


### PR DESCRIPTION
I suppose it's technically an ec2 key pair, but I didn't want to break the Aws naming pattern.
