### PR TITLE
Provide methods to create and delete VPC Subnets

### DIFF
--- a/docs/examples/aws_vpc.rb
+++ b/docs/examples/aws_vpc.rb
@@ -6,6 +6,12 @@ with_data_center 'eu-west-1' do
     cidr_block "10.0.1.0/24"
   end
 
+  subnet "provisioning-vpc-subnet-a" do
+    cidr_block "10.0.1.0/26"
+    vpc "provisioning-vpc"
+    availability_zone "eu-west-1a"
+  end
+
   aws_security_group "provisioning-vpc-security-group" do 
     inbound_rules [ 
       {:ports => 2223, :protocol => :tcp, :sources => ["10.0.0.0/24"] },

--- a/lib/chef/provider/aws_subnet.rb
+++ b/lib/chef/provider/aws_subnet.rb
@@ -1,0 +1,52 @@
+require 'chef/provider/aws_provider'
+require 'date'
+
+class Chef::Provider::AwsSubnet < Chef::Provider::AwsProvider
+
+  action :create do
+    fail "Can't create a Subnet without a CIDR block" if new_resource.cidr_block.nil?
+
+    if existing_subnet == nil
+      converge_by "Creating new Subnet #{fqn} in VPC #{new_resource.vpc} in #{new_resource.region_name}" do
+        opts = { :vpc => vpc_id }
+	opts[:availability_zone] = new_resource.availability_zone if new_resource.availability_zone
+        subnet = ec2.subnets.create(new_resource.cidr_block, opts)
+        subnet.tags['Name'] = new_resource.name
+        subnet.tags['VPC'] = new_resource.vpc
+        new_resource.subnet_id subnet.id
+        new_resource.save
+      end
+    end
+  end
+
+  action :delete do
+    if existing_subnet
+      converge_by "Deleting subnet #{fqn} in VPC #{new_resource.vpc} in #{new_resource.region_name}" do
+        existing_subnet.delete
+      end
+    end
+
+    new_resource.delete
+  end
+
+  def vpc_id
+    @vpc_id ||= begin
+      ec2.vpcs.with_tag('Name', new_resource.vpc).first
+    rescue
+      nil
+    end
+  end
+
+  def existing_subnet
+      @subnet_id ||= begin
+      ec2.subnets.with_tag('Name', new_resource.name).first
+    rescue
+      nil
+    end
+  end
+
+  def id
+    new_resource.subnet_id
+  end
+
+end

--- a/lib/chef/provisioning/aws_driver/resources.rb
+++ b/lib/chef/provisioning/aws_driver/resources.rb
@@ -1,4 +1,4 @@
-resources = %w(sqs_queue sns_topic ebs_volume s3_bucket auto_scaling_group launch_config vpc security_group eip_address)
+resources = %w(sqs_queue sns_topic ebs_volume s3_bucket auto_scaling_group launch_config vpc security_group eip_address subnet)
 
 resources.each do |r|
   Chef::Log.debug "AWS driver loading resource: #{r}"

--- a/lib/chef/resource/aws_subnet.rb
+++ b/lib/chef/resource/aws_subnet.rb
@@ -1,0 +1,25 @@
+require 'chef/resource/aws_resource'
+require 'chef/provisioning/aws_driver'
+
+class Chef::Resource::AwsSubnet < Chef::Resource::AwsResource
+  self.resource_name = 'aws_subnet'
+  self.databag_name = 'aws_subnet'
+
+  actions :create, :delete, :nothing
+  default_action :create
+
+  attribute :name, :kind_of => String, :name_attribute => true
+  attribute :cidr_block, :kind_of => String
+  attribute :vpc, :kind_of => String
+  attribute :availability_zone, :kind_of => String
+
+  stored_attribute :subnet_id
+
+  def initialize(*args)
+    super
+  end
+
+  def after_created
+    super
+  end
+end


### PR DESCRIPTION
A provider for provisioning subnets within an AWS VPC Environment.

```
  subnet "provisioning-vpc-subnet-a" do
    cidr_block "10.0.1.0/26"
    vpc "provisioning-vpc"
    availability_zone "eu-west-1a"
  end
```

Omitting `availablity zone` would have Amazon pick the AZ for you.