### PR TITLE
Make LB options optional

### DIFF
--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -66,7 +66,7 @@ module AWSDriver
       lb_optionals = {}
       lb_optionals[:security_groups] = [security_group] if security_group
       lb_optionals[:availability_zones] = availability_zones if availability_zones
-      lb_optionals[:listeners] = listeners
+      lb_optionals[:listeners] = listeners if listeners
 
       actual_elb = load_balancer_for(lb_spec)
       if !actual_elb.exists?
@@ -543,11 +543,17 @@ module AWSDriver
         end
       end
 
+
+
       # Only warn the first time
       default_warning = 'Using default key, which is not shared between machines!  It is recommended to create an AWS key pair with the fog_key_pair resource, and set :bootstrap_options => { :key_name => <key name> }'
       Chef::Log.warn(default_warning) if updated
 
       default_key_name
+    end
+
+    def image_for(image_spec)
+      compute.images.get(image_spec.location['image_id'])
     end
 
   end

--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -16,7 +16,6 @@ require 'chef/provisioning/aws_driver/credentials'
 require 'yaml'
 require 'aws-sdk-v1'
 
-
 class Chef
 module Provisioning
 module AWSDriver
@@ -53,16 +52,21 @@ module AWSDriver
 
     # Load balancer methods
     def allocate_load_balancer(action_handler, lb_spec, lb_options, machine_specs)
-      security_group_name = lb_options[:security_group_name] || 'default'
+      security_group_name = lb_options[:security_group_name]
       security_group_id = lb_options[:security_group_id]
 
-      security_group = if security_group_id.nil?
+      security_group = if security_group_id.nil? && !security_group_name.nil?
                          ec2.security_groups.filter('group-name', security_group_name).first
-                       else
+                       elsif !security_group_id.nil?
                          ec2.security_groups[security_group_id]
                        end
       availability_zones = lb_options[:availability_zones]
       listeners = lb_options[:listeners]
+
+      lb_optionals = {}
+      lb_optionals[:security_groups] = [security_group] if security_group
+      lb_optionals[:availability_zones] = availability_zones if availability_zones
+      lb_optionals[:listeners] = listeners
 
       actual_elb = load_balancer_for(lb_spec)
       if !actual_elb.exists?
@@ -74,10 +78,7 @@ module AWSDriver
         updates << "  with security group #{security_group.name}" if security_group
 
         action_handler.perform_action updates do
-          actual_elb = elb.load_balancers.create(lb_spec.name,
-            availability_zones: availability_zones,
-            listeners:          listeners,
-            security_groups:    [security_group])
+          actual_elb = elb.load_balancers.create(lb_spec.name, lb_optionals)
 
           lb_spec.location = {
             'driver_url' => driver_url,


### PR DESCRIPTION
I am getting this stack trace when I try to provision the `simple.rb` cluster from the example docs:

````
AWS::ELB::Errors::InvalidConfigurationRequest: load_balancer[webapp-elb] (@recipe_files::/home/bgoad/git/chef-provisioning-aws/docs/examples/simple.rb line 17) had an error: AWS::ELB::Errors::InvalidConfigurationRequest: Security group(s) can be applied to only an ELB in VPC.
/home/bgoad/.rvm/gems/ruby-2.1.0/gems/aws-sdk-v1-1.59.1/lib/aws/core/client.rb:375:in `return_or_raise'
/home/bgoad/.rvm/gems/ruby-2.1.0/gems/aws-sdk-v1-1.59.1/lib/aws/core/client.rb:476:in `client_request'
(eval):3:in `create_load_balancer'
/home/bgoad/.rvm/gems/ruby-2.1.0/gems/aws-sdk-v1-1.59.1/lib/aws/elb/load_balancer_collection.rb:116:in `create'
/home/bgoad/git/chef-provisioning-aws/lib/chef/provisioning/aws_driver/driver.rb:77:in `block in allocate_load_balancer'
/home/bgoad/.rvm/gems/ruby-2.1.0/gems/chef-11.16.4/lib/chef/mixin/why_run.rb:52:in `call'
/home/bgoad/.rvm/gems/ruby-2.1.0/gems/chef-11.16.4/lib/chef/mixin/why_run.rb:52:in `add_action'
/home/bgoad/.rvm/gems/ruby-2.1.0/gems/chef-11.16.4/lib/chef/provider.rb:156:in `converge_by'
/home/bgoad/.rvm/gems/ruby-2.1.0/bundler/gems/chef-provisioning-c9e700525163/lib/chef/provisioning/chef_provider_action_handler.rb:54:in `perform_action'
/home/bgoad/git/chef-provisioning-aws/lib/chef/provisioning/aws_driver/driver.rb:76:in `allocate_load_balancer'
/home/bgoad/.rvm/gems/ruby-2.1.0/bundler/gems/chef-provisioning-c9e700525163/lib/chef/provider/load_balancer.rb:30:in `block in <class:LoadBalancer>'
/home/bgoad/.rvm/gems/ruby-2.1.0/gems/chef-11.16.4/lib/chef/provider/lwrp_base.rb:138:in `instance_eval'
/home/bgoad/.rvm/gems/ruby-2.1.0/gems/chef-11.16.4/lib/chef/provider/lwrp_base.rb:138:in `block in action'
/home/bgoad/.rvm/gems/ruby-2.1.0/gems/chef-11.16.4/lib/chef/provider.rb:121:in `run_action'
/home/bgoad/.rvm/gems/ruby-2.1.0/gems/chef-11.16.4/lib/chef/resource.rb:648:in `run_action'
/home/bgoad/.rvm/gems/ruby-2.1.0/gems/chef-11.16.4/lib/chef/runner.rb:49:in `run_action'
/home/bgoad/.rvm/gems/ruby-2.1.0/gems/chef-11.16.4/lib/chef/runner.rb:81:in `block (2 levels) in converge'
/home/bgoad/.rvm/gems/ruby-2.1.0/gems/chef-11.16.4/lib/chef/runner.rb:81:in `each'
/home/bgoad/.rvm/gems/ruby-2.1.0/gems/chef-11.16.4/lib/chef/runner.rb:81:in `block in converge'
/home/bgoad/.rvm/gems/ruby-2.1.0/gems/chef-11.16.4/lib/chef/resource_collection.rb:98:in `block in execute_each_resource'
/home/bgoad/.rvm/gems/ruby-2.1.0/gems/chef-11.16.4/lib/chef/resource_collection/stepable_iterator.rb:116:in `call'
/home/bgoad/.rvm/gems/ruby-2.1.0/gems/chef-11.16.4/lib/chef/resource_collection/stepable_iterator.rb:116:in `call_iterator_block'
/home/bgoad/.rvm/gems/ruby-2.1.0/gems/chef-11.16.4/lib/chef/resource_collection/stepable_iterator.rb:85:in `step'
/home/bgoad/.rvm/gems/ruby-2.1.0/gems/chef-11.16.4/lib/chef/resource_collection/stepable_iterator.rb:104:in `iterate'
/home/bgoad/.rvm/gems/ruby-2.1.0/gems/chef-11.16.4/lib/chef/resource_collection/stepable_iterator.rb:55:in `each_with_index'
/home/bgoad/.rvm/gems/ruby-2.1.0/gems/chef-11.16.4/lib/chef/resource_collection.rb:96:in `execute_each_resource'
/home/bgoad/.rvm/gems/ruby-2.1.0/gems/chef-11.16.4/lib/chef/runner.rb:80:in `converge'
/home/bgoad/.rvm/gems/ruby-2.1.0/gems/chef-11.16.4/lib/chef/client.rb:345:in `converge'
/home/bgoad/.rvm/gems/ruby-2.1.0/gems/chef-11.16.4/lib/chef/client.rb:431:in `do_run'
/home/bgoad/.rvm/gems/ruby-2.1.0/gems/chef-11.16.4/lib/chef/client.rb:213:in `block in run'
/home/bgoad/.rvm/gems/ruby-2.1.0/gems/chef-11.16.4/lib/chef/client.rb:207:in `fork'
/home/bgoad/.rvm/gems/ruby-2.1.0/gems/chef-11.16.4/lib/chef/client.rb:207:in `run'
/home/bgoad/.rvm/gems/ruby-2.1.0/gems/chef-11.16.4/lib/chef/application.rb:236:in `run_chef_client'
/home/bgoad/.rvm/gems/ruby-2.1.0/gems/chef-11.16.4/lib/chef/application/client.rb:338:in `block in run_application'
/home/bgoad/.rvm/gems/ruby-2.1.0/gems/chef-11.16.4/lib/chef/application/client.rb:327:in `loop'
/home/bgoad/.rvm/gems/ruby-2.1.0/gems/chef-11.16.4/lib/chef/application/client.rb:327:in `run_application'
/home/bgoad/.rvm/gems/ruby-2.1.0/gems/chef-11.16.4/lib/chef/application.rb:55:in `run'
/home/bgoad/.rvm/gems/ruby-2.1.0/gems/chef-11.16.4/bin/chef-client:26:in `<top (required)>'
/home/bgoad/.rvm/gems/ruby-2.1.0/bin/chef-client:23:in `load'
/home/bgoad/.rvm/gems/ruby-2.1.0/bin/chef-client:23:in `<main>'
/home/bgoad/.rvm/gems/ruby-2.1.0/bin/ruby_executable_hooks:15:in `eval'
/home/bgoad/.rvm/gems/ruby-2.1.0/bin/ruby_executable_hooks:15:in `<main>'
````

Investigating the code, the `allocate_load_balancer` in the chef-provisioning-aws driver passes on security_group, availability_zones, and listeners options by default. However, the aws-sdk code indicates these are all optional, and in fact security_groups is only available with a VPC. In the case above, I could not create a new ELB  because we don't use VPC. 

I updated the driver code to make passing these three options truly optional. 