### PR TITLE
Support load_balancers and desired_capacity in aws_auto_scaling_group

### DIFF
--- a/lib/chef/provider/aws_auto_scaling_group.rb
+++ b/lib/chef/provider/aws_auto_scaling_group.rb
@@ -7,6 +7,7 @@ class Chef::Provider::AwsAutoScalingGroup < Chef::Provider::AwsProvider
         @existing_group = auto_scaling.groups.create(
           new_resource.name,
           :launch_configuration => new_resource.launch_config,
+          :desired_capacity => new_resource.desired_capacity,
           :min_size => new_resource.min_size,
           :max_size => new_resource.max_size,
           :availability_zones => availability_zones

--- a/lib/chef/provider/aws_auto_scaling_group.rb
+++ b/lib/chef/provider/aws_auto_scaling_group.rb
@@ -3,14 +3,20 @@ require 'chef/provider/aws_provider'
 class Chef::Provider::AwsAutoScalingGroup < Chef::Provider::AwsProvider
   action :create do
     if existing_group.nil?
-      converge_by "Creating new Auto Scaling group #{id} in #{new_resource.region_name}" do
+      auto_scaling_opts = {
+        :launch_configuration => new_resource.launch_config,
+        :min_size => new_resource.min_size,
+        :max_size => new_resource.max_size,
+        :availability_zones => availability_zones
+      }
+      
+      auto_scaling_opts[:desired_capacity] = new_resource.desired_capacity if new_resource.desired_capacity
+      auto_scaling_opts[:load_balancers] = new_resource.load_balancers if new_resource.load_balancers
+       
+      converge_by "Creating new Auto Scaling group #{new_resource.name} in #{new_resource.region_name}" do
         @existing_group = auto_scaling.groups.create(
           new_resource.name,
-          :launch_configuration => new_resource.launch_config,
-          :desired_capacity => new_resource.desired_capacity,
-          :min_size => new_resource.min_size,
-          :max_size => new_resource.max_size,
-          :availability_zones => availability_zones
+          auto_scaling_opts
         )
 
         new_resource.save
@@ -20,7 +26,7 @@ class Chef::Provider::AwsAutoScalingGroup < Chef::Provider::AwsProvider
 
   action :delete do
     if existing_group
-      converge_by "Deleting Auto Scaling group #{id} in #{new_resource.region_name}" do
+      converge_by "Deleting Auto Scaling group #{new_resource.name} in #{new_resource.region_name}" do
         existing_group.delete!
       end
     end

--- a/lib/chef/resource/aws_auto_scaling_group.rb
+++ b/lib/chef/resource/aws_auto_scaling_group.rb
@@ -13,4 +13,5 @@ class Chef::Resource::AwsAutoScalingGroup < Chef::Resource::AwsResource
   attribute :launch_config, :kind_of => String
   attribute :min_size, :kind_of => Integer, :default => 1
   attribute :max_size, :kind_of => Integer, :default => 4
+  attribute :load_balancers, :kind_of => Array
 end


### PR DESCRIPTION
Added load_balancers attribute, as this is a mainstream scenario for autoscaling. Also fixed so desired_capacity attribute is actually passed through to ec2, and updated a converge message to use the group name rather than undefined id.
