### PR TITLE
Add scheme and subnets to loadbalancer

### DIFF
--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -64,7 +64,7 @@ module AWSDriver
       if lb_options[:security_group_id]
         security_group = ec2.security_groups[:security_group_id]
       elsif lb_options[:security_group_name]
-        security_group = ec2.security_groups.filter('group-name', lb_options[:security_group_name])
+        security_group = ec2.security_groups.filter('group-name', lb_options[:security_group_name]).first
       end
 
       availability_zones = lb_options[:availability_zones]

--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -69,11 +69,15 @@ module AWSDriver
 
       availability_zones = lb_options[:availability_zones]
       listeners = lb_options[:listeners]
+      subnets = lb_options[:subnets]
+      scheme = lb_options[:scheme]
 
       lb_optionals = {}
       lb_optionals[:security_groups] = [security_group] if security_group
       lb_optionals[:availability_zones] = availability_zones if availability_zones
       lb_optionals[:listeners] = listeners if listeners
+      lb_optionals[:subnets] = subnets if subnets
+      lb_optionals[:scheme] = scheme if scheme
 
       actual_elb = load_balancer_for(lb_spec)
       if !actual_elb.exists?


### PR DESCRIPTION
The subnets option allows for creating a loadbalancer in a different subnet, to put it in another VPC than the default one.
The scheme option allows for creating an internal loadbalancer, as opposed to the default which is internet-facing (even though the docs say otherwise)

ref: http://docs.aws.amazon.com/AWSRubySDK/latest/AWS/ELB/LoadBalancerCollection.html#create-instance_method