### PR TITLE
Add scheme and subnets to loadbalancer

### DIFF
--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -65,7 +65,7 @@ module AWSDriver
       if lb_options[:security_group_id]
         security_group = ec2.security_groups[:security_group_id]
       elsif lb_options[:security_group_name]
-        security_group = ec2.security_groups.filter('group-name', lb_options[:security_group_name])
+        security_group = ec2.security_groups.filter('group-name', lb_options[:security_group_name]).first
       end
 
       availability_zones = lb_options[:availability_zones]

--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -70,11 +70,15 @@ module AWSDriver
 
       availability_zones = lb_options[:availability_zones]
       listeners = lb_options[:listeners]
+      subnets = lb_options[:subnets]
+      scheme = lb_options[:scheme]
 
       lb_optionals = {}
       lb_optionals[:security_groups] = [security_group] if security_group
       lb_optionals[:availability_zones] = availability_zones if availability_zones
       lb_optionals[:listeners] = listeners if listeners
+      lb_optionals[:subnets] = subnets if subnets
+      lb_optionals[:scheme] = scheme if scheme
 
       actual_elb = load_balancer_for(lb_spec)
       if !actual_elb.exists?

--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -63,9 +63,9 @@ module AWSDriver
     def allocate_load_balancer(action_handler, lb_spec, lb_options, machine_specs)
       lb_options ||= {}
       if lb_options[:security_group_id]
-        security_group = ec2.security_groups[:security_group_id]
+        security_groups = ec2.security_groups[:security_group_id]
       elsif lb_options[:security_group_name]
-        security_group = ec2.security_groups.filter('group-name', lb_options[:security_group_name]).first
+        security_groups = ec2.security_groups.filter('group-name', lb_options[:security_group_name])
       end
 
       availability_zones = lb_options[:availability_zones]
@@ -74,7 +74,7 @@ module AWSDriver
       scheme = lb_options[:scheme]
 
       lb_optionals = {}
-      lb_optionals[:security_groups] = [security_group] if security_group
+      lb_optionals[:security_groups] = (security_groups.map { |sg| sg.id }) if security_groups
       lb_optionals[:availability_zones] = availability_zones if availability_zones
       lb_optionals[:listeners] = listeners if listeners
       lb_optionals[:subnets] = subnets if subnets
@@ -84,10 +84,12 @@ module AWSDriver
       if !actual_elb.exists?
         perform_action = proc { |desc, &block| action_handler.perform_action(desc, &block) }
 
+        security_group_names = security_groups.map { |sg| sg.name }.join(",")
+
         updates = [ "Create load balancer #{lb_spec.name} in #{@region}" ]
         updates << "  enable availability zones #{availability_zones.join(', ')}" if availability_zones && availability_zones.size > 0
         updates << "  with listeners #{listeners.join(', ')}" if listeners && listeners.size > 0
-        updates << "  with security group #{security_group.name}" if security_group
+        updates << "  with security groups #{security_group_names}" if security_groups
 
         action_handler.perform_action updates do
           actual_elb = elb.load_balancers.create(lb_spec.name, lb_optionals)

--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -63,7 +63,7 @@ module AWSDriver
     def allocate_load_balancer(action_handler, lb_spec, lb_options, machine_specs)
       lb_options ||= {}
       if lb_options[:security_group_id]
-        security_groups = ec2.security_groups[:security_group_id]
+        security_groups = [ec2.security_groups[lb_options[:security_group_id]]]
       elsif lb_options[:security_group_name]
         security_groups = ec2.security_groups.filter('group-name', lb_options[:security_group_name])
       end


### PR DESCRIPTION
The subnets option allows for creating a loadbalancer in a different subnet, to put it in another VPC than the default one.
The scheme option allows for creating an internal loadbalancer, as opposed to the default which is internet-facing (even though the docs say otherwise)

ref: http://docs.aws.amazon.com/AWSRubySDK/latest/AWS/ELB/LoadBalancerCollection.html#create-instance_method