### PR TITLE
Fix specs require

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require 'chef/mixin/shell_out'
 require 'chef/dsl/recipe'
 require 'chef/provisioning'
 require 'chef/provisioning/aws_driver'


### PR DESCRIPTION
With ChefDK 0.4.0 I'm unable to run 'bundle exec rspec spec' until
I add this require.