### PR TITLE
Fix undefined local variable or method `image_id’ error

### DIFF
--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -291,7 +291,7 @@ EOD
       if actual_instance == nil || !actual_instance.exists? || actual_instance.status == :terminated
         bootstrap_options = bootstrap_options_for(action_handler, machine_spec, machine_options)
 
-        action_handler.perform_action "Create #{machine_spec.name} with AMI #{image_id} in #{@region}" do
+        action_handler.perform_action "Create #{machine_spec.name} with AMI #{bootstrap_options[:image_id]} in #{@region}" do
           Chef::Log.debug "Creating instance with bootstrap options #{bootstrap_options}"
 
           instance = ec2.instances.create(bootstrap_options.to_hash)


### PR DESCRIPTION
This appears to have been missed in ca4ca1f7c5.