### PR TITLE
Bug fixes for creating load balancers

### DIFF
--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -124,14 +124,14 @@ module AWSDriver
 
         # Update listeners
         perform_listener_action = proc do |desc, &block|
-          perform_listener_action = proc { |desc, &block| perform_action(desc, &block) }
+          perform_listener_action = proc { |desc, &block| perform_action.call(desc, &block) }
         end
         add_listeners = {}
         listeners.each { |l| add_listeners[l[:port]] = l } if listeners
         actual_elb.listeners.each do |listener|
           desired_listener = add_listeners.delete(listener.port)
           if desired_listener
-            if listener.protocol != desired_listener[:protocol]
+            if listener.protocol != desired_listener[:protocol].to_sym.downcase
               perform_listener_action.call("    update protocol from #{listener.protocol.inspect} to #{desired_listener[:protocol].inspect}'") do
                 listener.protocol = desired_listener[:protocol]
               end
@@ -141,7 +141,7 @@ module AWSDriver
                 listener.instance_port = desired_listener[:instance_port]
               end
             end
-            if listener.instance_protocol != desired_listener[:instance_protocol]
+            if listener.instance_protocol != desired_listener[:instance_protocol].to_sym.downcase
               perform_listener_action.call("    update instance protocol from #{listener.instance_protocol.inspect} to #{desired_listener[:instance_protocol].inspect}'") do
                 listener.instance_protocol = desired_listener[:instance_protocol]
               end


### PR DESCRIPTION
I was seeing two bugs when trying to create a load balancer:

1. When I did not use the correct keys for the `listeners` object, I was getting weird errors.  This was caused by https://github.com/chef/chef-provisioning-aws/blob/1a33c43bb81d7a3955d5e3eb657d7c82ce4f9021/lib/chef/provisioning/aws_driver/driver.rb#L130 so I added a validate method to prevent weird errors in the future.
2. `add_listeners` is being populated as a hash from port to listener, but was being accessed as an array - I fixed this with https://github.com/chef/chef-provisioning-aws/blob/7d689836cf0ba1cce4f41301ddcf6a1713c5cdef/lib/chef/provisioning/aws_driver/driver.rb#L160
3. When trying to update the listener object, users can supply either `HTTP` or :http as the protocol.  These should be equivalent so no listener update should be issued.  I fixed this with https://github.com/chef/chef-provisioning-aws/blob/1a33c43bb81d7a3955d5e3eb657d7c82ce4f9021/lib/chef/provisioning/aws_driver/driver.rb#L134
4. Updating the listener on an existing ELB was calling an unknown method `perform_action` - looking at the code, I thought you meant to call this? https://github.com/chef/chef-provisioning-aws/blob/1a33c43bb81d7a3955d5e3eb657d7c82ce4f9021/lib/chef/provisioning/aws_driver/driver.rb#L127
5. listeners are immutable - must delete and recreate if config is modified

@jkeiser I'm still confused by these procs-within-procs to call the actions - can we add some comments or figure out a cleaner way to present this?