### PR TITLE
Security groups, subnets and schemes can be updated

### DIFF
--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -118,7 +118,7 @@ module AWSDriver
         # TODO: refactor this whole giant method into many smaller method calls
         # Update scheme - scheme is immutable once set, so if it is changing we need to delete the old
         # ELB and create a new one
-        if scheme.downcase != actual_elb.scheme
+        if scheme && scheme.downcase != actual_elb.scheme
           desc = ["  updating scheme to #{scheme}"]
           desc << "  WARN: scheme is immutable, so deleting and re-creating the ELB"
           perform_action.call(desc) do
@@ -151,16 +151,16 @@ module AWSDriver
           enable_zones = (availability_zones || []).dup
           disable_zones = []
           actual_elb.availability_zones.each do |availability_zone|
-            if !enable_zones.delete(availability_zone.name)
+            unless enable_zones.delete(availability_zone.name)
               disable_zones << availability_zone.name
             end
           end
-          if enable_zones.size > 0
+          unless enable_zones.empty?
             perform_action.call("  enable availability zones #{enable_zones.join(', ')}") do
               actual_elb.availability_zones.enable(*enable_zones)
             end
           end
-          if disable_zones.size > 0
+          unless disable_zones.empty?
             perform_action.call("  disable availability zones #{disable_zones.join(', ')}") do
               actual_elb.availability_zones.disable(*disable_zones)
             end
@@ -171,11 +171,11 @@ module AWSDriver
           attach_subnets = (subnets || []).dup
           detach_subnets = []
           actual_elb.subnets.each do |subnet|
-            if !attach_subnets.delete(subnet.id)
+            unless attach_subnets.delete(subnet.id)
               detach_subnets << subnet.id
             end
           end
-          if attach_subnets.size > 0
+          unless attach_subnets.empty?
             perform_action.call("  attach subnets #{attach_subnets.join(', ')}") do
               elb.client.attach_load_balancer_to_subnets(
                 load_balancer_name: actual_elb.name,
@@ -183,7 +183,7 @@ module AWSDriver
               )
             end
           end
-          if detach_subnets.size > 0
+          unless detach_subnets.empty?
             perform_action.call("  detach subnets #{detach_subnets.join(', ')}") do
               elb.client.detach_load_balancer_from_subnets(
                 load_balancer_name: actual_elb.name,

--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -69,6 +69,8 @@ module AWSDriver
 
       availability_zones = lb_options[:availability_zones]
       listeners = lb_options[:listeners]
+      subnets = lb_options[:subnets]
+      scheme = lb_options[:scheme]
 
       validate_listeners(listeners)
 
@@ -76,6 +78,8 @@ module AWSDriver
       lb_optionals[:security_groups] = [security_group] if security_group
       lb_optionals[:availability_zones] = availability_zones if availability_zones
       lb_optionals[:listeners] = listeners if listeners
+      lb_optionals[:subnets] = subnets if subnets
+      lb_optionals[:scheme] = scheme if scheme
 
       actual_elb = load_balancer_for(lb_spec)
       if !actual_elb.exists?

--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -165,7 +165,7 @@ module AWSDriver
 
           # Only 1 of subnet or AZ will be populated b/c of our check earlier
           desired_subnets_zones = {}
-          (availability_zones || []).each do |zone|
+          availability_zones.each do |zone|
             # If the user specifies availability zone, we find the default subnet for that
             # AZ because this duplicates the create logic
             zone = zone.downcase

--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -64,7 +64,7 @@ module AWSDriver
       if lb_options[:security_group_id]
         security_group = ec2.security_groups[:security_group_id]
       elsif lb_options[:security_group_name]
-        security_group = ec2.security_groups.filter('group-name', lb_options[:security_group_name])
+        security_group = ec2.security_groups.filter('group-name', lb_options[:security_group_name]).first
       end
 
       availability_zones = lb_options[:availability_zones]

--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -62,7 +62,7 @@ module AWSDriver
     def allocate_load_balancer(action_handler, lb_spec, lb_options, machine_specs)
       lb_options ||= {}
       if lb_options[:security_group_id]
-        security_groups = ec2.security_groups[:security_group_id]
+        security_groups = [ec2.security_groups[lb_options[:security_group_id]]]
       elsif lb_options[:security_group_name]
         security_groups = ec2.security_groups.filter('group-name', lb_options[:security_group_name])
       end

--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -17,7 +17,6 @@ require 'chef/provisioning/aws_driver/credentials'
 
 require 'yaml'
 require 'aws-sdk-v1'
-require 'set'
 
 # loads the entire aws-sdk
 AWS.eager_autoload!
@@ -151,8 +150,8 @@ module AWSDriver
             end
           end
         else
-          current = Set.new(actual_elb.security_group_ids)
-          desired = Set.new(security_group_ids)
+          current = actual_elb.security_group_ids
+          desired = security_group_ids
           if current != desired
             perform_action.call("  updating security groups to #{desired.to_a}") do
               elb.client.apply_security_groups_to_load_balancer(
@@ -207,7 +206,7 @@ module AWSDriver
         end
 
         # We only bother attaching subnets, because doing this automatically attaches the AZ
-        attach_subnets = (Set.new(desired_subnets_zones.keys) - Set.new(actual_zones_subnets.keys)).to_a
+        attach_subnets = desired_subnets_zones.keys - actual_zones_subnets.keys
         unless attach_subnets.empty?
           action = "  attach subnets #{attach_subnets.join(', ')}"
           enable_zones = (desired_subnets_zones.map {|s,z| z if attach_subnets.include?(s)}).compact
@@ -228,7 +227,7 @@ module AWSDriver
           end
         end
 
-        detach_subnets = (Set.new(actual_zones_subnets.keys) - Set.new(desired_subnets_zones.keys)).to_a
+        detach_subnets = actual_zones_subnets.keys - desired_subnets_zones.keys
         unless detach_subnets.empty?
           action = "  detach subnets #{detach_subnets.join(', ')}"
           disable_zones = (actual_zones_subnets.map {|s,z| z if detach_subnets.include?(s)}).compact

--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -130,25 +130,8 @@ module AWSDriver
 
         # Update security groups
         if security_group_ids.empty?
-          Chef::Log.debug("No Security Groups specified but ELB cannot have 0 SGs. Reverting to default SG.")
-          filters = [{:name => 'isDefault', :values => ['true']}]
-          default_vpc = ec2.client.describe_vpcs(:filters => filters)[:vpc_set][0][:vpc_id]
-          # Apparently AWS creates multiple default security groups
-          # http://stackoverflow.com/questions/27829620/what-are-the-default-security-groups-created-when-i-set-up-aws-eb-for-the-first
-          filters = [
-            {:name => 'vpc-id', :values => [default_vpc]},
-            {:name => 'group-name', :values => ['default_elb*']}
-          ]
-          sgs = ec2.client.describe_security_groups(:filters => filters)
-          default_sg = sgs[:security_group_info][0][:group_id]
-          if [default_sg] != actual_elb.security_group_ids
-            perform_action.call("  applying default security group #{default_sg}") do
-              elb.client.apply_security_groups_to_load_balancer(
-                load_balancer_name: actual_elb.name,
-                security_groups: [default_sg]
-              )
-            end
-          end
+            Chef::Log.debug("No Security Groups specified. Load_balancer[#{actual_elb.name}] cannot have " +
+            "empty Security Groups, so assuming it only currently has the default Security Group.  No action taken.")
         else
           current = actual_elb.security_group_ids
           desired = security_group_ids


### PR DESCRIPTION
This completes the work started in https://github.com/chef/chef-provisioning-aws/pull/97 - that correctly created a LB with the desired attributes, but did not update an converge an existing LB to the desired state.

\cc @jkeiser @fnichol @erikvanbrakel 