### PR TITLE
Fix #116 and #114

### DIFF
--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -187,7 +187,7 @@ module AWSDriver
   
         if instance_ids_to_remove.size > 0
           perform_action.call("  remove instances #{instance_ids_to_remove}") do
-            actual_elb.instances.remove(instance_ids_to_remove)
+            actual_elb.instances.remove(*instance_ids_to_remove.to_a())
           end
         end
       end

--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -50,7 +50,7 @@ module AWSDriver
       @aws_config = AWS::Core::Configuration.new(
         access_key_id:     credentials[:aws_access_key_id],
         secret_access_key: credentials[:aws_secret_access_key],
-        region: region
+        region: region || credentials[:region]
       )
     end
 


### PR DESCRIPTION
For #116, I added back the logic to set region to the profile in credentials if not specified on driver

For #114, I allowed a load balancer to be created when machines is not specified at all. In this case, it will not try to delete existing instances. This is needed so it can work with an autoscaling cluster resource that specifies a load balancer.