### PR TITLE
Fix specs

### DIFF
--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -50,7 +50,8 @@ module AWSDriver
       @aws_config = AWS::Core::Configuration.new(
         access_key_id:     credentials[:aws_access_key_id],
         secret_access_key: credentials[:aws_secret_access_key],
-        region: region || credentials[:region]
+        region: region || credentials[:region],
+        stub_requests: AWS.config.stub_requests
       )
     end
 

--- a/spec/unit/provider/aws_subnet_spec.rb
+++ b/spec/unit/provider/aws_subnet_spec.rb
@@ -5,9 +5,7 @@ AWS.stub!
 describe Chef::Provider::AwsSubnet do
   extend ChefZeroRspecHelper
   let(:new_resource) {
-    resource = Chef::Resource::AwsSubnet.new('my_subnet', run_context)
-    resource.driver 'aws'
-    resource
+    Chef::Resource::AwsSubnet.new('my_subnet', run_context)
   }
   let(:my_node) {
     node = Chef::Node.new
@@ -18,7 +16,9 @@ describe Chef::Provider::AwsSubnet do
   let(:events) { Chef::EventDispatch::Dispatcher.new }
   let(:run_context) {
     cookbook_collection = {}
-    Chef::RunContext.new(my_node, cookbook_collection ,events)
+    run_context = Chef::RunContext.new(my_node, cookbook_collection, events)
+    run_context.chef_provisioning.with_driver 'aws'
+    run_context
   }
 
   subject(:provider) {

--- a/spec/unit/provider/aws_subnet_spec.rb
+++ b/spec/unit/provider/aws_subnet_spec.rb
@@ -5,7 +5,9 @@ AWS.stub!
 describe Chef::Provider::AwsSubnet do
   extend ChefZeroRspecHelper
   let(:new_resource) {
-    Chef::Resource::AwsSubnet.new('my_subnet', run_context)
+    resource = Chef::Resource::AwsSubnet.new('my_subnet', run_context)
+    resource.driver 'aws'
+    resource
   }
   let(:my_node) {
     node = Chef::Node.new


### PR DESCRIPTION
Support for 'with_driver' and 'driver' (PR #111) broke the recently added specs. This seems to fix it, but is there a better way?