### PR TITLE
Make security groups idempotent, add better syntax

### DIFF
--- a/docs/examples/ref.rb
+++ b/docs/examples/ref.rb
@@ -17,18 +17,14 @@ end
 
 aws_security_group 'ref-sg1' do
   vpc 'ref-vpc'
-  inbound_rules [ { ports: 22, protocol: :tcp, sources: [ '0.0.0.0/0' ] } ]
+  inbound_rules '0.0.0.0/0' => 22
 end
 
 aws_security_group 'ref-sg2' do
   vpc 'ref-vpc'
 
-  inbound_rules [
-    {:ports => 2223, :protocol => :tcp, :sources => ['ref-sg1'] }
-  ]
-  outbound_rules [
-    {:ports => 2223, :protocol => :tcp, :destinations => ['ref-sg1'] }
-  ]
+  inbound_rules 'ref-sg1' => 2224
+  outbound_rules 2224 => 'ref-sg1'
 end
 
 aws_route_table 'ref-public' do

--- a/docs/examples/sg_test.rb
+++ b/docs/examples/sg_test.rb
@@ -1,0 +1,100 @@
+with_driver 'aws'
+
+require 'chef/provisioning/aws_driver'
+
+vpc = aws_vpc 'test-vpc' do
+  cidr_block '10.0.0.0/24'
+  internet_gateway true
+end
+
+# Empty
+
+aws_security_group 'test-sg' do
+  vpc 'test-vpc'
+  action :delete
+end
+
+aws_security_group 'test-sg' do
+  vpc 'test-vpc'
+end
+aws_security_group 'test-sg' do
+  vpc 'test-vpc'
+end
+
+# Things we can reference
+aws_security_group 'other-sg' do
+  vpc 'test-vpc'
+end
+
+aws_subnet 'test-subnet' do
+  vpc 'test-vpc'
+end
+
+recipe = self
+ruby_block 'lb' do
+  block do
+    recipe.load_balancer 'other-lb' do
+      load_balancer_options subnets: vpc.aws_object.subnets.map { |s| s }
+    end
+  end
+end
+
+# Add/update
+aws_security_group 'test-sg' do
+  vpc 'test-vpc'
+  action :delete
+end
+aws_security_group 'test-sg' do
+  vpc 'test-vpc'
+  inbound_rules '0.0.0.0/0'                   => 22,
+                'other-sg'                    => 1024..2048,
+                { load_balancer: 'other-lb' } => 1024..2048
+  outbound_rules 443        => '0.0.0.0/0',
+                 2048..4096 => 'other-sg',
+                 2048..4096 => { load_balancer: 'other-lb' }
+end
+
+# Add one inbound rule, change one inbound rule, add to one inbound rule
+aws_security_group 'test-sg' do
+  vpc 'test-vpc'
+  inbound_rules '0.0.0.0/0' => 80,
+                'other-sg'  => [ 80, 1024..2048 ],
+                '127.0.0.1' => 1024..2048,
+                { load_balancer: 'other-lb' } => 1024..2048
+end
+
+# Add one outbound rule, change one outbound rule, add to one outbound rule
+aws_security_group 'test-sg' do
+  vpc 'test-vpc'
+  outbound_rules 80                 => '0.0.0.0/0',
+                 [ 80, 2048..4096 ] => 'other-sg',
+                 2048..4096         => '127.0.0.1',
+                 1024..2048         => { load_balancer: 'other-lb' }
+end
+
+
+# Idempotence
+aws_security_group 'test-sg' do
+  vpc 'test-vpc'
+  inbound_rules '0.0.0.0/0'                   => 80,
+                'other-sg'                    => [ 80, 1024..2048 ],
+                '127.0.0.1'                   => 1024..2048,
+                { load_balancer: 'other-lb' } => 1024..2048
+  outbound_rules 80                 => '0.0.0.0/0',
+                 [ 80, 2048..4096 ] => 'other-sg',
+                 2048..4096         => '127.0.0.1',
+                 1024..2048         => { load_balancer: 'other-lb' }
+end
+
+# Idempotence (alternate way of writing it)
+aws_security_group 'test-sg' do
+  vpc 'test-vpc'
+  inbound_rules [{ port: 80, sources: [ '0.0.0.0/0' ] },
+                { port: [ 80, 1024..2048 ], sources: [ 'other-sg' ] },
+                { port: 1024..2048, sources: [ '127.0.0.1' ] },
+                { port: 1024..2048, sources: [ { load_balancer: 'other-lb' } ] }]
+  outbound_rules [{ port: 80, destinations: [ '0.0.0.0/0', 'other-sg' ] },
+                 { port: [ 80, 2048..4096 ], destinations: [ 'other-sg' ] },
+                 { port: 2048..4096, destinations: [ 'other-sg', '127.0.0.1' ] },
+                 { port: 1024..2048, destinations: [ { load_balancer: 'other-lb' } ] }]
+end

--- a/docs/examples/sg_test.rb
+++ b/docs/examples/sg_test.rb
@@ -1,6 +1,6 @@
-with_driver 'aws'
-
 require 'chef/provisioning/aws_driver'
+
+with_driver 'aws::eu-west-1'
 
 vpc = aws_vpc 'test-vpc' do
   cidr_block '10.0.0.0/24'
@@ -97,4 +97,24 @@ aws_security_group 'test-sg' do
                  { port: [ 80, 2048..4096 ], destinations: [ 'other-sg' ] },
                  { port: 2048..4096, destinations: [ 'other-sg', '127.0.0.1' ] },
                  { port: 1024..2048, destinations: [ { load_balancer: 'other-lb' } ] }]
+end
+
+load_balancer 'other-lb' do
+  action :destroy
+end
+
+aws_subnet 'test-subnet' do
+  action :delete
+end
+
+aws_security_group 'test-sg' do
+  action :delete
+end
+
+aws_security_group 'other-sg' do
+  action :delete
+end
+
+aws_vpc 'test-vpc' do
+  action :delete
 end

--- a/lib/chef/provider/aws_security_group.rb
+++ b/lib/chef/provider/aws_security_group.rb
@@ -1,83 +1,288 @@
 require 'chef/provisioning/aws_driver/aws_provider'
 require 'date'
 require 'ipaddr'
+require 'set'
 
 class Chef::Provider::AwsSecurityGroup < Chef::Provisioning::AWSDriver::AWSProvider
 
   action :create do
     sg = new_resource.aws_object
-    if !sg
-      converge_by "Creating new SG #{new_resource.name} in #{region}" do
-        options = { description: new_resource.description }
-        options[:vpc] = new_resource.vpc if new_resource.vpc
-        options = AWSResource.lookup_options(options, resource: new_resource)
-        Chef::Log.debug("VPC: #{options[:vpc]}")
-
-        sg = driver.ec2.security_groups.create(new_resource.name, options)
-      end
+    if sg
+      update_security_group(sg)
+    else
+      sg = create_security_group
     end
 
     new_resource.save_managed_entry(sg, action_handler)
 
-    # Update rules
-    apply_rules(sg)
+    vpc = sg.vpc
+
+    if !new_resource.outbound_rules.nil?
+      update_outbound_rules(sg, vpc)
+    end
+
+    if !new_resource.inbound_rules.nil?
+      update_inbound_rules(sg, vpc)
+    end
   end
 
   action :delete do
-    aws_object = new_resource.aws_object
-    if aws_object
-      converge_by "Deleting SG #{new_resource.name} in #{region}" do
-        aws_object.delete
+    sg = new_resource.aws_object
+    if sg
+      converge_by "delete SG #{new_resource.name} (#{sg.id}) in #{region}" do
+        sg.delete
       end
     end
 
     new_resource.delete_managed_entry(action_handler)
   end
 
-  # TODO check existing rules and compare / remove?
-  def apply_rules(security_group)
-    # Incoming
-    if new_resource.inbound_rules
-      new_resource.inbound_rules.each do |rule|
-        begin
-          converge_by "Updating SG #{new_resource.name} in #{region} to allow inbound #{rule[:protocol]}/#{rule[:ports]} from #{rule[:sources]}" do
-            sources = get_sources(rule[:sources])
-            security_group.authorize_ingress(rule[:protocol], rule[:ports], *sources)
-          end
-        rescue AWS::EC2::Errors::InvalidPermission::Duplicate
-          Chef::Log.debug 'Duplicate rule, ignoring.'
-        end
-      end
-    end
+  private
 
-    # Outgoing
-    if new_resource.outbound_rules
-      new_resource.outbound_rules.each do |rule|
-        begin
-          converge_by "Updating SG #{new_resource.name} in #{region} to allow outbound #{rule[:protocol]}/#{rule[:ports]} to #{rule[:destinations]}" do
-            security_group.authorize_egress( *get_sources(rule[:destinations]), :protocol => rule[:protocol], :ports => rule[:ports])
-          end
-        rescue AWS::EC2::Errors::InvalidPermission::Duplicate
-          Chef::Log.debug 'Duplicate rule, ignoring.'
-        end
+  def update_security_group(sg)
+    if !new_resource.description.nil? && new_resource.description != sg.description
+      raise "Security Group descriptions cannot be changed after being created!  Desired description for #{new_resource.name} (#{sg.id}) was \"#{new_resource.description}\" and actual description is \"#{sg.description}\""
+    end
+    if !new_resource.vpc.nil?
+      desired_vpc = Chef::Resource::AwsVpc.get_aws_object_id(new_resource.vpc, resource: new_resource)
+      if desired_vpc != sg.vpc_id
+        raise "Security Group VPC cannot be changed after being created!  Desired VPC for #{new_resource.name} (#{sg.id}) was #{new_resource.vpc} (#{desired_vpc}) and actual VPC is #{sg.vpc_id}"
       end
     end
   end
 
-  # TODO need support for load balancers!
-  def get_sources(sources)
-    sources.map do |s|
-      if s.is_a?(String)
-        begin
-          IPAddr.new(s)
-          s
-        rescue
-          { group_id: Chef::Resource::AwsSecurityGroup.get_aws_object_id(s, resource: new_resource) }
+  def create_security_group
+    sg = nil
+    converge_by "create new SG #{new_resource.name} in #{region}" do
+      options = { description: new_resource.description }
+      options[:vpc] = new_resource.vpc if new_resource.vpc
+      options = AWSResource.lookup_options(options, resource: new_resource)
+      Chef::Log.debug("VPC: #{options[:vpc]}")
+
+      sg = driver.ec2.security_groups.create(new_resource.name, options)
+    end
+    sg
+  end
+
+  def update_inbound_rules(sg, vpc)
+    #
+    # Get desired rules
+    #
+    desired_rules = {}
+
+    case new_resource.inbound_rules
+    when Hash
+      new_resource.inbound_rules.each do |sources_spec, port_spec|
+        add_rule(desired_rules, get_port_ranges(port_spec), get_actors(vpc, sources_spec))
+      end
+
+    when Array
+      # [ { port: X, protocol: Y, sources: [ ... ]}]
+      new_resource.inbound_rules.each do |rule|
+        port_ranges = get_port_ranges(port_range: rule[:port], protocol: rule[:protocol])
+        add_rule(desired_rules, port_ranges, get_actors(vpc, rule[:sources]))
+      end
+
+    else
+      raise ArgumentError, "inbound_rules must be a Hash or Array (was #{new_resource.inbound_rules.inspect})"
+    end
+
+    #
+    # Actually update the rules (remove, add)
+    #
+    update_rules(desired_rules, sg.ip_permissions_list,
+
+      authorize: proc do |port_range, protocol, actors|
+        names = actors.map { |a| a.is_a?(Hash) ? a[:group_id] : a }
+        converge_by "authorize #{names.join(', ')} to send traffic to group #{new_resource.name} (#{sg.id}) on port_range #{port_range} with protocol #{protocol}" do
+          sg.authorize_ingress(protocol, port_range, *actors)
         end
-      else
-        s
+      end,
+
+      revoke: proc do |port_range, protocol, actors|
+        names = actors.map { |a| a.is_a?(Hash) ? a[:group_id] : a }
+        converge_by "revoke the ability of #{names.join(', ')} to send traffic to group #{new_resource.name} (#{sg.id}) on port_range #{port_range} with protocol #{protocol}" do
+          sg.revoke_ingress(protocol, port_range, *actors)
+        end
+      end)
+  end
+
+  def update_outbound_rules(sg, vpc)
+    #
+    # Get desired rules
+    #
+    desired_rules = {}
+
+    case new_resource.outbound_rules
+    when Hash
+      new_resource.outbound_rules.each do |port_spec, sources_spec|
+        add_rule(desired_rules, get_port_ranges(port_spec), get_actors(vpc, sources_spec))
+      end
+
+    when Array
+      # [ { port: X, protocol: Y, sources: [ ... ]}]
+      new_resource.outbound_rules.each do |rule|
+        port_ranges = get_port_ranges(port_range: rule[:port], protocol: rule[:protocol])
+        add_rule(desired_rules, port_ranges, get_actors(vpc, rule[:destinations]))
+      end
+
+    else
+      raise ArgumentError, "outbound_rules must be a Hash or Array (was #{new_resource.outbound_rules.inspect})"
+    end
+
+    #
+    # Actually update the rules (remove, add)
+    #
+    update_rules(desired_rules, sg.ip_permissions_list_egress,
+
+      authorize: proc do |port_range, protocol, actors|
+        names = actors.map { |a| a.is_a?(Hash) ? a[:group_id] : a }
+        converge_by "authorize group #{new_resource.name} (#{sg.id}) to send traffic to #{names.join(', ')} on port_range #{port_range} with protocol #{protocol}" do
+          sg.authorize_egress(*actors, ports: port_range, protocol: protocol)
+        end
+      end,
+
+      revoke: proc do |port_range, protocol, actors|
+        names = actors.map { |a| a.is_a?(Hash) ? a[:group_id] : a }
+        converge_by "revoke the ability of group #{new_resource.name} (#{sg.id}) to send traffic to #{names.join(', ')} on port_range #{port_range} with protocol #{protocol}" do
+          sg.revoke_egress(*actors, ports: port_range, protocol: protocol)
+        end
+      end)
+  end
+
+  def update_rules(desired_rules, actual_rules_list, authorize: nil, revoke: nil)
+    actual_rules = {}
+    actual_rules_list.each do |rule|
+      port_range = {
+        port_range: rule[:from_port] ? rule[:from_port]..rule[:to_port] : nil,
+        protocol: rule[:ip_protocol].to_s.to_sym
+      }
+      add_rule(actual_rules, [ port_range ], rule[:groups]) if rule[:groups]
+      add_rule(actual_rules, [ port_range ], rule[:ip_ranges].map { |r| r[:cidr_ip] }) if rule[:ip_ranges]
+    end
+
+    #
+    # Get the list of permissions to add and remove
+    #
+    actual_rules.each do |port_range, actors|
+      if desired_rules[port_range]
+        intersection = actors & desired_rules[port_range]
+        # Anything unhandled in desired_rules will be added
+        desired_rules[port_range] -= intersection
+        # Anything unhandled in actual_rules will be removed
+        actual_rules[port_range] -= intersection
       end
     end
+
+    #
+    # Add any new rules
+    #
+    desired_rules.each do |port_range, actors|
+      unless actors.empty?
+        authorize.call(port_range[:port_range], port_range[:protocol], actors)
+      end
+    end
+
+    #
+    # Remove any rules no longer in effect
+    #
+    actual_rules.each do |port_range, actors|
+      unless actors.empty?
+        revoke.call(port_range[:port_range], port_range[:protocol], actors)
+      end
+    end
+  end
+
+  def add_rule(rules, port_ranges, actors)
+    unless actors.empty?
+      port_ranges.each do |port_range|
+        rules[port_range] ||= Set.new
+        rules[port_range] += actors
+      end
+    end
+  end
+
+  def get_port_ranges(port_spec)
+    case port_spec
+    when Integer
+      [ { port_range: port_spec..port_spec, protocol: :tcp } ]
+    when Range
+      [ { port_range: port_spec, protocol: :tcp } ]
+    when Array
+      port_spec.map { |p| get_port_ranges(p) }.flatten
+    when Hash
+      if port_spec[:protocol]
+        [ { port_range: port_spec[:port_range] || port_spec[:port], protocol: port_spec[:protocol].to_s.to_sym } ]
+      else
+        get_port_ranges(port_spec[:port_range] || port_spec[:port])
+      end
+      # The to_s.to_sym dance is because if you specify a protocol number, AWS symbolifies it,
+      # but 26.to_sym doesn't work (so we have to to_s it first).
+    when nil
+      [ { port_range: nil, protocol: :any } ]
+    end
+  end
+
+  #
+  # Turns an actor_spec into a uniform array, containing CIDRs, AWS::EC2::LoadBalancers and AWS::EC2::SecurityGroups.
+  #
+  def get_actors(vpc, actor_spec)
+    result = case actor_spec
+
+    # An array is always considered a list of actors.  Each one may follow any supported format.
+    when Array
+      actor_spec.map { |a| get_actors(vpc, a) }
+
+    # Hashes come in several forms:
+    when Hash
+      # The default AWS Ruby SDK form with :user_id, :group_id and :group_name forms
+      if actor_spec.keys.all? { |key| [ :user_id, :group_id, :group_name ].include?(key) }
+        if actor_spec.has_key?(:group_name)
+          actor_spec[:group_id] ||= vpc.security_groups.filter('group-name', actor_spec[:group_name]).first.id
+        end
+        actor_spec[:user_id] ||= new_resource.driver.account_id
+        { user_id: actor_spec[:user_id], group_id: actor_spec[:group_id] }
+
+      # load_balancer: <load balancer name>
+      elsif actor_spec.keys == [ :load_balancer ]
+        lb = Chef::Resource::AwsLoadBalancer.get_aws_object(actor_spec.values.first, resource: new_resource)
+        get_actors(vpc, lb)
+
+      # security_group: <security group name>
+      elsif actor_spec.keys == [ :security_group ]
+        Chef::Resource::AwsSecurityGroup.get_aws_object(actor_spec[:security_group], resource: new_resource)
+
+      else
+        raise "Unable to reference security group with spec #{actor_spec}"
+      end
+
+    # If a load balancer is specified, grab it and then get its automatic security group
+    when /^elb-[a-fA-F0-9]{8}$/, AWS::ELB::LoadBalancer, Chef::Resource::AwsLoadBalancer
+      lb = Chef::Resource::AwsLoadBalancer.get_aws_object(actor_spec, resource: new_resource)
+      get_actors(vpc, lb.source_security_group)
+
+    # If a security group is specified, grab it
+    when /^sg-[a-fA-F0-9]{8}$/, AWS::EC2::SecurityGroup, Chef::Resource::AwsSecurityGroup
+      Chef::Resource::AwsSecurityGroup.get_aws_object(actor_spec, resource: new_resource)
+
+    # If an IP addresses / CIDR are passed, return it verbatim; otherwise, assume it's the
+    # name of a security group.
+    when String
+      begin
+        IPAddr.new(actor_spec)
+        # Add /32 to the end of raw IP addresses
+        actor_spec =~ /\// ? actor_spec : "#{actor_spec}/32"
+      rescue
+        Chef::Resource::AwsSecurityGroup.get_aws_object(actor_spec, resource: new_resource)
+      end
+
+    else
+      raise "Unexpected actor #{actor_spec} in rules list"
+    end
+
+    result = { user_id: result.owner_id, group_id: result.id } if result.is_a?(AWS::EC2::SecurityGroup)
+
+    [ result ].flatten
   end
 
 end

--- a/lib/chef/provider/aws_subnet.rb
+++ b/lib/chef/provider/aws_subnet.rb
@@ -60,14 +60,14 @@ class Chef::Provider::AwsSubnet < Chef::Provisioning::AWSDriver::AWSProvider
   def update_subnet(subnet)
     # Verify unmodifiable attributes of existing subnet
     if new_resource.cidr_block && subnet.cidr_block != new_resource.cidr_block
-      raise "cidr_block for subnet #{new_resource.name} is #{new_resource.cidr_block}, but existing subnet (#{subnet.id})'s cidr_block is #{new_resource.cidr_block}.  Modification of subnet cidr_block is unsupported!"
+      raise "cidr_block for subnet #{new_resource.name} is #{new_resource.cidr_block}, but existing subnet (#{subnet.id})'s cidr_block is #{subnet.cidr_block}.  Modification of subnet cidr_block is unsupported!"
     end
     vpc = Chef::Resource::AwsVpc.get_aws_object(new_resource.vpc, resource: new_resource)
     if vpc && subnet.vpc != vpc
       raise "vpc for subnet #{new_resource.name} is #{new_resource.vpc} (#{vpc.id}), but existing subnet (#{subnet.id})'s vpc is #{subnet.vpc.id}.  Modification of subnet vpc is unsupported!"
     end
     if new_resource.availability_zone && subnet.availability_zone != new_resource.availability_zone
-      raise "availability_zone for subnet #{new_resource.name} is #{new_resource.availability_zone}, but existing subnet (#{subnet.id})'s availability_zone is #{new_resource.availability_zone}.  Modification of subnet availability_zone is unsupported!"
+      raise "availability_zone for subnet #{new_resource.name} is #{new_resource.availability_zone.inspect}, but existing subnet (#{subnet.id})'s availability_zone is #{subnet.availability_zone.inspect}.  Modification of subnet availability_zone is unsupported!"
     end
   end
 

--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -64,7 +64,6 @@ module AWSDriver
 
       old_elb = nil
       actual_elb = load_balancer_for(lb_spec)
-      puts "Actual #{actual_elb.inspect} for #{lb_spec.reference}"
       if !actual_elb || !actual_elb.exists?
         lb_options[:listeners] ||= get_listeners(:http)
         if !lb_options[:subnets] && !lb_options[:availability_zones] && machine_specs

--- a/lib/chef/provisioning/aws_driver/super_lwrp.rb
+++ b/lib/chef/provisioning/aws_driver/super_lwrp.rb
@@ -33,6 +33,12 @@ class Chef
             super
           end
         end
+
+        # FUUUUUU cloning
+        def load_prior_resource(*args)
+          Chef::Log.debug "Overloading #{self.resource_name} load_prior_resource with NOOP"
+        end
+
       end
     end
   end

--- a/lib/chef/resource/aws_security_group.rb
+++ b/lib/chef/resource/aws_security_group.rb
@@ -7,11 +7,45 @@ class Chef::Resource::AwsSecurityGroup < Chef::Provisioning::AWSDriver::AWSResou
   actions :create, :delete, :nothing
   default_action :create
 
-  attribute :name,          kind_of: String, name_attribute: true
-  attribute :vpc,           kind_of: [ String, AwsVpc, AWS::EC2::VPC ]
-  attribute :description,   kind_of: String
-  attribute :inbound_rules
-  attribute :outbound_rules
+  attribute :name,           kind_of: String, name_attribute: true
+  attribute :vpc,            kind_of: [ String, AwsVpc, AWS::EC2::VPC ]
+  attribute :description,    kind_of: String
+
+  #
+  # Accepts rules in the format:
+  # [
+  #   { port: 22, protocol: :tcp, sources: [<source>, <source>, ...] }
+  # ]
+  #
+  # Or:
+  # {
+  #   <permitted_source> => <port>,
+  #   ...
+  # }
+  #
+  # Where <port> is one of:
+  # - <port number/range>: the port number. e.g. `80`; or a port range: `1024..2048`
+  # - [ <port number/range>, <protocol> ] or [ <protocol>, <number> ], e.g. `[ 80, :http ]`
+  # - { port: <port number/range>, protocol: <protocol> }, e.g. { port: 80, protocol: :http }
+  #
+  # And <permitted_source> is one of:
+  # - <CIDR>: An IP or CIDR of IPs to talk to.
+  #   - `inbound_rules '1.2.3.4' => 80`
+  #   - `inbound_rules '1.2.3.4/24' => 80`
+  # - <Security Group>: A security group to authorize.
+  #   - `inbound_rules 'mysecuritygroup'`
+  #   - `inbound_rules { security_group: 'mysecuritygroup' }`
+  #   - `inbound_rules 'sg-1234abcd' => 80`
+  #   - `inbound_rules aws_security_group('mysecuritygroup') => 80`
+  #   - `inbound_rules AWS.ec2.security_groups.first => 80`
+  # - <Load Balancer>: A load balancer to authorize.
+  #   - `inbound_rules { load_balancer: 'myloadbalancer' } => 80`
+  #   - `inbound_rules 'elb-1234abcd' => 80`
+  #   - `inbound_rules load_balancer('myloadbalancer') => 80`
+  #   - `inbound_rules AWS.ec2.security_groups.first => 80`
+  #
+  attribute :inbound_rules,  kind_of: [ Array, Hash ]
+  attribute :outbound_rules, kind_of: [ Array, Hash ]
 
   attribute :security_group_id, kind_of: String, aws_id_attribute: true, lazy_default: proc {
     name =~ /^sg-[a-f0-9]{8}$/ ? name : nil

--- a/spec/integration/aws_security_group_spec.rb
+++ b/spec/integration/aws_security_group_spec.rb
@@ -1,0 +1,145 @@
+require 'spec_helper'
+require 'cheffish/rspec/chef_run_support'
+require 'chef/provisioning/aws_driver/credentials'
+
+describe 'AWS Security Group' do
+  extend Cheffish::RSpec::ChefRunSupport
+
+  when_the_chef_server "exists", :osc_compat => false do
+
+    let(:ec2_client) { double(AWS::EC2::Client) }
+    let!(:entry_store) { Chef::Provisioning::ChefManagedEntryStore.new }
+
+    before :each do
+      allow_any_instance_of(AWS.config.class).to receive(:ec2_client).and_return(ec2_client)
+      allow(Chef::Provisioning::ChefManagedEntryStore).to receive(:new).and_return(entry_store)
+      allow_any_instance_of(Chef::Provisioning::AWSDriver::Credentials).to receive(:default)
+        .and_return({
+          :aws_access_key_id => 'na',
+          :aws_secret_access_key => 'na'
+        })
+    end
+
+    describe "create" do
+      let(:vpc_id) { "vpc-12345" }
+      let(:vpc_name) { "my_vpc" }
+      let(:sg_name) { "test_sg" }
+      let(:create_hash) do
+        {
+          :cidr_block=>"10.0.0.0/24",
+          :instance_tenancy=>"default"
+        }
+      end
+      let(:create_resp) do
+        resp = AWS::Core::Response.new
+        resp.data[:vpc] = {
+          :tag_set=>[],
+          :vpc_id=>vpc_id,
+          :cidr_block=>"10.0.0.0/24",
+          :instance_tenancy=>"default"
+        }
+        resp
+      end
+      let(:describe_resp) do
+        resp = AWS::Core::Response.new
+        resp.data[:vpc_set] = [{
+          :vpc_id => vpc_id,
+          :cidr_block => "10.0.0.0/24",
+          :state => 'created',
+          :dhcp_options_id => 'yggdrasil',
+          :tag_set => [],
+          :instance_tenancy => 'default',
+          :is_default => true
+        }]
+        resp.request_type = :describe_vpcs
+      end
+      let(:sg_create_resp) do
+        resp = AWS::Core::Response.new
+        resp.data[:group_id] = "sg-09876"
+        resp
+      end
+
+      before do
+        expect(ec2_client).to receive(:create_vpc).with(create_hash).and_return(create_resp)
+        expect(ec2_client).to receive(:create_tags).with({
+          :resources=>[vpc_id],
+          :tags=>[{:key=>"Name", :value=>vpc_name}]
+        })
+        expect(ec2_client).to receive(:describe_vpcs).with({:vpc_ids=>[vpc_id]})
+          .and_return(describe_resp)
+        expect(ec2_client).to receive(:create_security_group).with({
+          :group_name=>sg_name,
+          :description=>sg_name,
+          :vpc_id=>vpc_id
+        }).and_return(sg_create_resp)
+      end
+
+      context "when VPC is supplied as a resource name" do
+        it "creates the security group" do
+          run_recipe do
+            with_driver 'aws::us-west-2'
+            aws_vpc "my_vpc" do
+              cidr_block '10.0.0.0/24'
+            end
+            aws_security_group 'test_sg' do
+              vpc "my_vpc"
+            end
+          end
+
+          expect(chef_run).to have_updated('aws_vpc[my_vpc]', :create)
+          expect(chef_run).to have_updated('aws_security_group[test_sg]', :create)
+        end
+      end
+
+      context "when VPC is supplied as a aws object identifier" do
+        it "creates the security group" do
+          run_recipe do
+            with_driver 'aws::us-west-2'
+            aws_security_group 'test_sg' do
+              vpc "vpc-12345"
+            end
+          end
+
+          expect(chef_run).to have_updated('aws_vpc[my_vpc]', :create)
+          expect(chef_run).to have_updated('aws_security_group[test_sg]', :create)
+        end
+      end
+
+      context "when VPC is supplied as a chef resource" do
+        it "creates the security group" do
+          run_recipe do
+            with_driver 'aws::us-west-2'
+            v = aws_vpc "my_vpc" do
+              cidr_block '10.0.0.0/24'
+            end
+            aws_security_group 'test_sg' do
+              vpc v
+            end
+          end
+
+          expect(chef_run).to have_updated('aws_vpc[my_vpc]', :create)
+          expect(chef_run).to have_updated('aws_security_group[test_sg]', :create)
+        end
+      end
+
+      context "when VPC is supplied as a aws object" do
+        it "creates the security group" do
+          run_recipe do
+            with_driver 'aws::us-west-2'
+            v = aws_vpc "my_vpc" do
+              cidr_block '10.0.0.0/24'
+            end
+            aws_security_group 'test_sg' do
+              vpc v.aws_object
+            end
+          end
+
+          expect(chef_run).to have_updated('aws_vpc[my_vpc]', :create)
+          expect(chef_run).to have_updated('aws_security_group[test_sg]', :create)
+        end
+      end
+
+    end
+
+  end
+end


### PR DESCRIPTION
```ruby
aws_security_group 'blah' do
  inbound_rules 'other-security-group' => 80 # allow other security groups to hit 80
  outbound_rules 80 => '0.0.0.0/0' # allow members of this security group to send traffic to port 80 of anything
end
```