### PR TITLE
network interface (create, update, destroy)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ docs/examples/clients
 docs/examples/nodes
 docs/examples/data_bags
 x.rb
+.idea/

--- a/docs/examples/aws_network_interface.rb
+++ b/docs/examples/aws_network_interface.rb
@@ -1,0 +1,124 @@
+require 'chef/provisioning/aws_driver'
+require 'retryable'
+
+with_driver 'aws::us-west-2'
+
+aws_key_pair 'ref-key-pair-eni'
+
+aws_dhcp_options 'ref-dhcp-options-eni'
+
+aws_vpc 'ref-vpc-eni' do
+  cidr_block '10.0.0.0/24'
+  internet_gateway true
+  main_routes '0.0.0.0/0' => :internet_gateway
+  dhcp_options 'ref-dhcp-options-eni'
+end
+
+aws_security_group 'ref-sg1-eni' do
+  vpc 'ref-vpc-eni'
+  inbound_rules '0.0.0.0/0' => 22
+end
+
+aws_security_group 'ref-sg2-eni' do
+  vpc 'ref-vpc-eni'
+  inbound_rules 'ref-sg1-eni' => 2224
+  outbound_rules 2224 => 'ref-sg1-eni'
+end
+
+aws_route_table 'ref-public-eni' do
+  vpc 'ref-vpc-eni'
+  routes '0.0.0.0/0' => :internet_gateway
+end
+
+aws_subnet 'ref-subnet-eni' do
+  vpc 'ref-vpc-eni'
+  map_public_ip_on_launch true
+  route_table 'ref-public-eni'
+end
+
+with_machine_options :bootstrap_options => {
+    :subnet_id => 'ref-subnet-eni',
+    :key_name => 'ref-key-pair-eni',
+    :security_group_ids => ['ref-sg1-eni', 'ref-sg2-eni']
+  }
+
+ref_machine = machine 'ref-machine-eni-1' do
+  action :allocate
+end
+
+aws_network_interface 'ref-eni-1' do
+  machine 'ref-machine-eni-1'
+  subnet 'ref-subnet-eni'
+  security_groups ['ref-sg1-eni']
+  description 'ref-eni-desc'
+end
+
+aws_network_interface 'ref-eni-1' do
+  security_groups ['ref-sg1-eni', 'ref-sg2-eni']
+  description 'new-ref-eni-desc'
+end
+
+aws_network_interface 'ref-eni-1' do
+  device_index 2
+end
+
+# raise can not be modifed exception
+# aws_network_interface 'ref-eni-1' do
+#   subnet 'subnet-f0836387'
+# end
+
+aws_network_interface 'ref-eni-1' do
+  machine false
+end
+
+aws_network_interface 'ref-eni-1' do
+  action :destroy
+end
+
+instance = nil
+ruby_block 'get instance' do
+  block do
+    instance = Chef::Resource::AwsInstance.get_aws_object(ref_machine.name, 
+      resource: ref_machine,
+      driver: run_context.chef_provisioning.current_driver,
+      run_context: run_context,
+      managed_entry_store: Chef::Provisioning.chef_managed_entry_store(ref_machine.chef_server)
+    )
+  end
+end
+
+machine 'ref-machine-eni-1' do
+  action :destroy
+end
+
+ruby_block 'wait for instance to terminate' do
+  block do
+    Retryable.retryable(:tries => 60, :sleep => 2) do
+      raise 'instance never terminated' if instance.status != :terminated
+    end
+  end
+end
+
+aws_subnet 'ref-subnet-eni' do
+  action :destroy
+end
+
+aws_route_table 'ref-public-eni' do
+  action :destroy
+end
+
+aws_security_group 'ref-sg2-eni' do
+  action :destroy
+end
+
+aws_security_group 'ref-sg1-eni' do
+  action :destroy
+end
+
+aws_vpc 'ref-vpc-eni' do
+  action :destroy
+end
+
+aws_dhcp_options 'ref-dhcp-options-eni' do
+  action :destroy
+end

--- a/lib/chef/provider/aws_network_interface.rb
+++ b/lib/chef/provider/aws_network_interface.rb
@@ -1,0 +1,209 @@
+require 'chef/provisioning/aws_driver/aws_provider'
+require 'cheffish'
+require 'date'
+require 'retryable'
+
+class Chef::Provider::AwsNetworkInterface < Chef::Provisioning::AWSDriver::AWSProvider
+  class NetworkInterfaceStatusTimeoutError < TimeoutError
+    def initialize(new_resource, initial_status, expected_status)
+      super("timed out waiting for #{new_resource} status to change from #{initial_status} to #{expected_status}!")
+    end
+  end
+
+  class NetworkInterfaceStatusTimeoutError < TimeoutError
+    def initialize(new_resource, initial_status, expected_status)
+      super("timed out waiting for #{new_resource} status to change from #{initial_status} to #{expected_status}!")
+    end
+  end
+
+  class NetworkInterfaceInvalidStatusError < RuntimeError
+    def initialize(new_resource, status)
+      super("#{new_resource} is in #{status} state!")
+    end
+  end
+
+  def action_create
+    eni = super
+
+    if !new_resource.machine.nil?
+      update_eni(eni)
+    end
+  end
+
+  protected
+
+  def create_aws_object
+    eni = nil
+    converge_by "create new #{new_resource} in #{region}" do
+      eni = new_resource.driver.ec2.network_interfaces.create(options)
+      eni.tags['Name'] = new_resource.name
+    end
+
+    converge_by "wait for new #{new_resource} in #{region} to become available" do
+      wait_for_eni_status(eni, :available)
+      eni
+    end
+  end
+
+  def update_aws_object(eni)
+    if options.has_key?(:subnet)
+      if Chef::Resource::AwsSubnet.get_aws_object(options[:subnet], resource: new_resource) != eni.subnet
+        raise "#{new_resource} subnet is #{new_resource.subnet}, but actual network interface has subnet set to #{eni.subnet_id}.  Cannot be modified!"
+      end
+    end
+
+    # TODO implement private ip reassignment
+    if options.has_key?(:private_ip_address)
+      if options[:private_ip_address] != eni.private_ip_address
+        raise "#{new_resource} private IP is #{new_resource.private_ip_address}, but actual network interface has private IP set to #{eni.private_ip_address}.  Private IP reassignment not implemented. Cannot be modified!"
+      end
+    end
+
+    if options.has_key?(:description)
+      if options[:description] != eni.description
+        converge_by "set #{new_resource} description to #{new_resource.description}" do
+          eni.client.modify_network_interface_attribute(:network_interface_id => eni.network_interface_id,
+                                                        :description => {
+                                                            :value => new_resource.description
+                                                        })
+        end
+      end
+    end
+
+    if options.has_key?(:security_groups)
+      groups = new_resource.security_groups.map { |sg|
+        Chef::Resource::AwsSecurityGroup.get_aws_object(sg, resource: new_resource)
+      }
+      if groups.sort != eni.security_groups.sort
+        converge_by "set #{new_resource} security groups to #{groups}" do
+          eni.set_security_groups(groups)
+          eni
+        end
+      end
+    end
+
+    eni
+  end
+
+  def destroy_aws_object(eni)
+    detach(eni) if eni.status == :in_use
+    delete(eni)
+  end
+
+  private
+
+  def expected_instance
+    # use instance if already set
+    @expected_instance ||= new_resource.machine ?
+      # if not, and machine is set, find and return the instance
+        Chef::Resource::AwsInstance.get_aws_object(new_resource.machine, resource: new_resource) :
+      # otherwise return nil
+        nil
+  end
+
+  def options
+    @options ||= begin
+      options = {}
+      options[:subnet] = new_resource.subnet if !new_resource.subnet.nil?
+      options[:private_ip_address] = new_resource.private_ip_address if !new_resource.private_ip_address.nil?
+      options[:description] = new_resource.description if !new_resource.description.nil?
+      options[:security_groups] = new_resource.security_groups if !new_resource.security_groups.nil?
+      options[:device_index] = new_resource.device_index if !new_resource.device_index.nil?
+
+      AWSResource.lookup_options(options, resource: new_resource)
+    end
+  end
+
+  def update_eni(eni)
+    status = eni.status
+    #
+    # If we were told to attach the network interface to a machine, do so
+    #
+    if expected_instance.is_a?(AWS::EC2::Instance)
+      case status
+      when :available
+        attach(eni)
+      when :in_use
+        # We don't want to attempt to reattach to the same instance or device index
+        attachment = current_attachment(eni)
+        if attachment.instance != expected_instance || (options[:device_index] && attachment.device_index != new_resource.device_index)
+          detach(eni)
+          attach(eni)
+        end
+      when nil
+        raise NetworkInterfaceNotFoundError.new(new_resource)
+      else
+        raise NetworkInterfaceInvalidStatusError.new(new_resource, status)
+      end
+
+    #
+    # If we were told to set the machine to false, detach it.
+    #
+    else
+      case status
+      when nil
+        Chef::Log.warn NetworkInterfaceNotFoundError.new(new_resource)
+      when :in_use
+        detach(eni)
+      end
+    end
+    eni
+  end
+    
+  def wait_for_eni_status(eni, expected_status)
+    initial_status = eni.status
+    log_callback = proc {
+      Chef::Log.info("waiting for #{new_resource} status to change to #{expected_status}...")
+    }
+
+    Retryable.retryable(:tries => 30, :sleep => 2, :on => NetworkInterfaceStatusTimeoutError, :ensure => log_callback) do
+      raise NetworkInterfaceStatusTimeoutError.new(new_resource, initial_status, expected_status) if eni.status != expected_status
+    end
+  end
+
+  def detach(eni)
+    attachment   = current_attachment(eni)
+    instance     = attachment.instance
+
+    converge_by "detach #{new_resource} from #{instance.instance_id}" do
+      eni.detach
+    end
+
+    converge_by "wait for #{new_resource} to detach" do
+      wait_for_eni_status(eni, :available)
+      eni
+    end
+  end
+
+  def attach(eni)
+    converge_by "attach #{new_resource} to #{new_resource.machine} (#{expected_instance.instance_id})" do
+      eni.attach(expected_instance, options)
+    end
+
+    converge_by "wait for #{new_resource} to attach" do
+      wait_for_eni_status(eni, :in_use)
+      eni
+    end
+  end
+
+  def current_attachment(eni)
+    eni.attachment
+  end
+
+  def delete(eni)
+    converge_by "delete #{new_resource} in #{region}" do
+      eni.delete
+    end
+
+    converge_by "wait for #{new_resource} in #{region} to delete" do
+      log_callback = proc {
+        Chef::Log.info('waiting for network interface to delete...')
+      }
+
+      Retryable.retryable(:tries => 30, :sleep => 2, :on => NetworkInterfaceStatusTimeoutError, :ensure => log_callback) do
+        raise NetworkInterfaceStatusTimeoutError.new(new_resource, 'exists', 'deleted') if eni.exists?
+      end
+      eni
+    end
+  end
+end

--- a/lib/chef/resource/aws_network_interface.rb
+++ b/lib/chef/resource/aws_network_interface.rb
@@ -1,16 +1,34 @@
 require 'chef/provisioning/aws_driver/aws_resource'
+require 'chef/resource/aws_subnet'
+require 'chef/resource/aws_eip_address'
 
-class Chef::Resource::AwsNetworkInterface < Chef::Provisioning::AWSDriver::AWSResource
-  aws_sdk_type AWS::EC2::NetworkInterface, load_provider: false, id: :id
+class Chef::Resource::AwsNetworkInterface < Chef::Provisioning::AWSDriver::AWSResourceWithEntry
+  aws_sdk_type AWS::EC2::NetworkInterface
 
-  attribute :name, kind_of: String, name_attribute: true
+  attribute :name,                   kind_of: String, name_attribute: true
 
-  attribute :network_interface_id, kind_of: String, aws_id_attribute: true, lazy_default: proc {
+  attribute :network_interface_id,   kind_of: String, aws_id_attribute: true, lazy_default: proc {
     name =~ /^eni-[a-f0-9]{8}$/ ? name : nil
   }
 
+  attribute :subnet,                 kind_of: [ String, AWS::EC2::Subnet, AwsSubnet ]
+
+  attribute :private_ip_address,     kind_of: String
+
+  attribute :description,            kind_of: String
+
+  attribute :security_groups,        kind_of: Array #(Array<SecurityGroup>, Array<String>)
+
+  attribute :machine,                kind_of: [ String, FalseClass, AwsInstance, AWS::EC2::Instance ]
+
+  attribute :device_index,           kind_of: Integer
+
+  # TODO implement eip address association
+  #attribute :elastic_ip_address,     kind_of: [ String, AWS::EC2::ElasticIp, AwsEipAddress, FalseClass ]
+
   def aws_object
-    result = driver.ec2.network_interfaces[network_interface_id]
+    driver, id = get_driver_and_id
+    result = driver.ec2.network_interfaces[id] if id
     result && result.exists? ? result : nil
   end
 end


### PR DESCRIPTION
Adds the ability to:
* create (with options)
* update (machine attachment, device index attachment, security groups)
* destroy

Not included:
* Elastic IP association

I'm somewhat procrastination on the specs.  I would prefer to wait the latest test framework is merged to master