### PR TITLE
Update chef-provisioning-aws.gemspec

### DIFF
--- a/chef-provisioning-aws.gemspec
+++ b/chef-provisioning-aws.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/opscode/chef-provisioning-aws'
 
   s.add_dependency 'chef', '>= 11.16.4'
-  s.add_dependency 'chef-provisioning', '~> 0.9'
+  s.add_dependency 'chef-provisioning', '~> 1.0.0.rc.1'
   s.add_dependency 'aws-sdk-v1'
   s.add_dependency 'retryable', '~> 2.0.1'
 


### PR DESCRIPTION
Can not install from a GemFile due to error `Could not find gem 'chef-provisioning (~> 0.9) ruby', which is required by gem 'chef-provisioning-aws (>= 0) ruby', in any of the sources.
`