### PR TITLE
Add ability to ignore certain routes

### DIFF
--- a/lib/chef/provider/aws_route_table.rb
+++ b/lib/chef/provider/aws_route_table.rb
@@ -7,7 +7,7 @@ class Chef::Provider::AwsRouteTable < Chef::Provisioning::AWSDriver::AWSProvider
     route_table = super
 
     if !new_resource.routes.nil?
-      update_routes(vpc, route_table)
+      update_routes(vpc, route_table, new_resource.ignore_route_targets)
     end
   end
 
@@ -53,12 +53,13 @@ class Chef::Provider::AwsRouteTable < Chef::Provisioning::AWSDriver::AWSProvider
 
   attr_accessor :vpc
 
-  def update_routes(vpc, route_table)
+  def update_routes(vpc, route_table, ignore_route_targets = [])
     # Collect current routes
     current_routes = {}
     route_table.routes.each do |route|
       # Ignore the automatic local route
       next if route.target.id == 'local'
+      next if ignore_route_targets.find { |target| route.target.id.match(/#{target}/) }
       current_routes[route.destination_cidr_block] = route
     end
 

--- a/lib/chef/resource/aws_route_table.rb
+++ b/lib/chef/resource/aws_route_table.rb
@@ -58,6 +58,26 @@ class Chef::Resource::AwsRouteTable < Chef::Provisioning::AWSDriver::AWSResource
   #
   attribute :routes, kind_of: Hash
 
+  #
+  # Regex to ignore one or more route targets.
+  #
+  # This is helpful when configuring HA NAT instances. If a NAT instance fails
+  # a auto-scaling group may launch a new NAT instance and update the route
+  # table accordingly. Chef provisioning should not attempt to change or remove
+  # this route.
+  #
+  # This attribute is specified as a regex since the full ID of the
+  # instance/network interface is not known ahead of time. In most cases the
+  # NAT instance route will point at a network interface attached to the NAT
+  # instance. The ID prefix for network interfaces is 'eni'. The following
+  # example shows how to ignore network interface routes.
+  #
+  # ```ruby
+  # ignore_route_targets ['^eni-']
+  # ```
+  attribute :ignore_route_targets, kind_of: [ String, Array ], default: [],
+            coerce: proc { |v| [v].flatten }
+
   attribute :route_table_id, kind_of: String, aws_id_attribute: true, lazy_default: proc {
     name =~ /^rtb-[a-f0-9]{8}$/ ? name : nil
   }

--- a/spec/integration/aws_route_table_spec.rb
+++ b/spec/integration/aws_route_table_spec.rb
@@ -35,6 +35,38 @@ describe Chef::Resource::AwsRouteTable do
           ]
         ).and be_idempotent
       end
+
+      it "ignores routes whose target matches ignore_route_targets" do
+        expect_recipe {
+            aws_subnet 'test_subnet' do
+              vpc 'test_vpc'
+            end
+
+            eni = aws_network_interface 'test_network_interface' do
+              subnet 'test_subnet'
+            end
+
+            aws_route_table 'test_route_table' do
+              vpc 'test_vpc'
+              routes(
+                '0.0.0.0/0' => :internet_gateway,
+                '172.31.0.0/16' => eni
+              )
+            end
+  
+            aws_route_table 'test_route_table' do
+              vpc 'test_vpc'
+              routes '0.0.0.0/0' => :internet_gateway
+              ignore_route_targets ['^eni-']
+            end
+          }.to create_an_aws_route_table('test_route_table',
+            routes: [
+              { destination_cidr_block: '10.0.0.0/24', 'target.id' => 'local', state: :active },
+              { destination_cidr_block: '172.31.0.0/16' },
+              { destination_cidr_block: '0.0.0.0/0', 'target.id' => test_vpc.aws_object.internet_gateway.id, state: :active },
+            ]
+          ).and be_idempotent
+      end
     end
   end
 end


### PR DESCRIPTION
I'm not sure if this is a great solution to the problem, but I do know it works. If nothing else it will spark some conversation about how best to handle the situation. Here's the problem:

There were 2 issues we encountered with route tables in AWS when they are managed by Chef provisioning.

1. When a VPN connection has static routes, you have the option to propagate those routes to any route table. This is necessary for traffic to flow between services on the far end of the VPN and the subnets inside AWS. If propagated routes are enabled Chef provisioning fails because it sees `vgw-abcd1234` as route targets. It tries to remove them since they aren't defined in Chef resources but it can't because they're a different kind of route. We thought maybe we could just add those routes to Chef explicitly but the API doesn't allow routes with target of `vgw-abcd1234`. It is best if we can just set these type of routes to be ignored.
2. Some things require more dynamic routes. For example, if NAT instances are set up in an HA configuration and one AZ's NAT instance dies it's peer will dynamically modify the route tables to point at a different instance or network interface. In this case, we need the ability to exclude `/^eni-/` or `/^i-/` so `i-abcd1234` and `eni-abcd1234` are ignored. 

With the changes in this PR a user can specify a route table as follows:
```
  aws_route_table 'my_route_table' do
    vpc 'my_vpc'
    routes 0.0.0.0/0 => :internet_gateway
    ignore_route_targets ['^vgw-','^i-']
  end
```

I hope these two scenarios make sense.