### PR TITLE
Add ability to turn off source/dest check

### DIFF
--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -408,6 +408,7 @@ EOD
           sleep 5 while instance.status == :pending
           # TODO add other tags identifying user / node url (same as fog)
           instance.tags['Name'] = machine_spec.name
+          instance.source_dest_check = machine_options[:source_dest_check] unless machine_options[:source_dest_check].nil?
           machine_spec.reference = {
               'driver_url' => driver_url,
               'driver_version' => Chef::Provisioning::AWSDriver::VERSION,
@@ -945,6 +946,7 @@ EOD
               'instance_id' => instance.id
             }
             instance.tags['Name'] = machine_spec.name
+            instance.source_dest_check = machine_options[:source_dest_check] unless machine_options[:source_dest_check].nil?
             machine_spec.reference['key_name'] = bootstrap_options[:key_name] if bootstrap_options[:key_name]
             %w(is_windows ssh_username sudo use_private_ip_for_ssh ssh_gateway).each do |key|
               machine_spec.reference[key] = machine_options[key.to_sym] if machine_options[key.to_sym]


### PR DESCRIPTION
Source/dest check needs to be off for NAT instances. This allows `source_dest_check: false` to be set as a `machine_options` key/value.