### PR TITLE
AWS Proxy & Session Token Support

### DIFF
--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -54,6 +54,8 @@ module AWSDriver
         access_key_id:     credentials[:aws_access_key_id],
         secret_access_key: credentials[:aws_secret_access_key],
         region: region || credentials[:region],
+        proxy_uri: credentials[:proxy_uri] || nil,
+        session_token: credentials[:aws_session_token] || nil,
         logger: Chef::Log.logger
       )
     end


### PR DESCRIPTION
As a Enterprise User I need to be able to tell chef-provisioning to use my corporate proxy and also my session token so I can pass-through and reach Amazon EC2.

cc/ @jonsmorrow @mfdii @jkeiser 