### PR TITLE
Added version constraint for aws-sdk.

### DIFF
--- a/chef-provisioning-aws.gemspec
+++ b/chef-provisioning-aws.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'chef', '>= 11.16.4'
   s.add_dependency 'chef-provisioning', '~> 1.0'
-  s.add_dependency 'aws-sdk-v1'
+  s.add_dependency 'aws-sdk-v1', '>= 1.59.0'
   s.add_dependency 'retryable', '~> 2.0.1'
 
   # chef-zero is only a development dependency because we leverage its RSpec support


### PR DESCRIPTION
I kept getting the following error when using map_public_ip_on_launch in the aws_subnet resource:

```
AWS::EC2::Errors::InvalidAction
    -------------------------------
    The action ModifySubnetAttribute is not valid for this web service.
```

It appears to be caused by my having an older version of aws-sdk in my Gemfile, which doesn't support the needed EC2 api. Because this project has no version constraint on aws-sdk, it happily used the older version, resulting in the error.

I put the version as >= 1.59.0 because that's the earliest version I found that supported ModifySubnetAttribute.
