### PR TITLE
Fixed incorrect resource params in vpc example.

### DIFF
--- a/docs/examples/aws_vpc.rb
+++ b/docs/examples/aws_vpc.rb
@@ -4,7 +4,7 @@ with_driver 'aws::eu-west-1'
   aws_vpc "provisioning-vpc" do
     cidr_block "10.0.0.0/24"
     internet_gateway true
-    internet_gateway_routes '0.0.0.0/0'
+    main_routes '0.0.0.0/0' => :internet_gateway
   end
 
   aws_subnet "provisioning-vpc-subnet-a" do
@@ -45,5 +45,5 @@ aws_security_group "provisioning-vpc-security-group" do
     {:ports => 2223, :protocol => :tcp, :destinations => ["1.1.1.0/16"] },
     {:ports => 8080, :protocol => :tcp, :destinations => ["2.2.2.0/24"] }
   ]
-  vpc_name "provisioning-vpc"
+  vpc "provisioning-vpc"
 end


### PR DESCRIPTION
I'm pretty sure what I added for main_routes is correct, but it's hard to tell because internet_gateway_routes seems to have never actually existed.