### PR TITLE
Updated security group examples to use the correct hash key for ports.

### DIFF
--- a/docs/examples/aws_sg.rb
+++ b/docs/examples/aws_sg.rb
@@ -3,12 +3,12 @@ require 'chef/provisioning/aws_driver'
 with_driver 'aws::eu-west-1' do
   aws_security_group "provisioning-security-group" do
     inbound_rules [
-      {:ports => 2223, :protocol => :tcp, :sources => ["10.0.0.0/24"] },
-      {:ports => 80..100, :protocol => :udp, :sources => ["1.1.1.0/24"] }
+      {:port => 2223, :protocol => :tcp, :sources => ["10.0.0.0/24"] },
+      {:port => 80..100, :protocol => :udp, :sources => ["1.1.1.0/24"] }
     ]
     outbound_rules [
-      {:ports => 2223, :protocol => :tcp, :destinations => ["1.1.1.0/16"] },
-      {:ports => 8080, :protocol => :tcp, :destinations => ["2.2.2.0/24"] }
+      {:port => 2223, :protocol => :tcp, :destinations => ["1.1.1.0/16"] },
+      {:port => 8080, :protocol => :tcp, :destinations => ["2.2.2.0/24"] }
     ]
   end
 end

--- a/docs/examples/aws_vpc.rb
+++ b/docs/examples/aws_vpc.rb
@@ -38,12 +38,12 @@ end
 
 aws_security_group "provisioning-vpc-security-group" do
   inbound_rules [
-    {:ports => 2223, :protocol => :tcp, :sources => ["10.0.0.0/24"] },
-    {:ports => 80..100, :protocol => :udp, :sources => ["1.1.1.0/24"] }
+    {:port => 2223, :protocol => :tcp, :sources => ["10.0.0.0/24"] },
+    {:port => 80..100, :protocol => :udp, :sources => ["1.1.1.0/24"] }
   ]
   outbound_rules [
-    {:ports => 2223, :protocol => :tcp, :destinations => ["1.1.1.0/16"] },
-    {:ports => 8080, :protocol => :tcp, :destinations => ["2.2.2.0/24"] }
+    {:port => 2223, :protocol => :tcp, :destinations => ["1.1.1.0/16"] },
+    {:port => 8080, :protocol => :tcp, :destinations => ["2.2.2.0/24"] }
   ]
   vpc_name "provisioning-vpc"
 end

--- a/docs/examples/ref_full.rb
+++ b/docs/examples/ref_full.rb
@@ -48,7 +48,7 @@ aws_security_group 'ref-sg1' do
   inbound_rules '0.0.0.0/0' => 22
   inbound_rules '0.0.0.0/0' => 80
   outbound_rules [
-    {:ports => 22..22, :protocol => :tcp, :destinations => ['0.0.0.0/0'] }
+    {:port => 22..22, :protocol => :tcp, :destinations => ['0.0.0.0/0'] }
   ]
 end
 


### PR DESCRIPTION
This one is especially tricky since it doesn't error when using "ports", but the rule gets created with a port range of 0..0.