### PR TITLE
Updating ref files to run correctly

### DIFF
--- a/docs/examples/ref_destroy.rb
+++ b/docs/examples/ref_destroy.rb
@@ -1,6 +1,6 @@
 require 'chef/provisioning/aws_driver'
 
-with_driver 'aws::eu-west-1'
+with_driver 'aws::us-west-1'
 
 aws_sqs_queue 'ref-sqs-queue' do
   action :destroy
@@ -69,6 +69,19 @@ end
 
 aws_key_pair 'ref-key-pair' do
   action :destroy
+end
+
+# You cannot delete the main route table, or delete a VPC which
+# has non-main route tables attached.  So we first need to restore
+# the 'default' route tabled created during the `create_vpc`
+# call as the main route table.  Then we can delete the
+# 'ref-main-route-table' (because it is no longer main)
+# and finally delete the VPC (which deletes the main route table)
+aws_vpc 'ref-vpc' do
+  main_route_table lazy {
+    self.aws_object.route_tables.select {|r| !r.main?}.first
+  }
+  only_if { !self.aws_object.nil? }
 end
 
 aws_route_table 'ref-main-route-table' do

--- a/docs/examples/ref_full.rb
+++ b/docs/examples/ref_full.rb
@@ -1,14 +1,14 @@
 require 'chef/provisioning/aws_driver'
 
-with_driver 'aws::eu-west-1'
+with_driver 'aws::us-west-1'
 
 #
 # This recipe sets every single value of every single object
 #
 
-aws_vpc 'ref-vpc' do
-  action :purge
-end
+# aws_vpc 'ref-vpc' do
+#   action :purge
+# end
 
 aws_dhcp_options 'ref-dhcp-options' do
   domain_name          'example.com'
@@ -37,15 +37,14 @@ aws_vpc 'ref-vpc' do
   main_route_table 'ref-main-route-table'
 end
 
-
 aws_key_pair 'ref-key-pair' do
   private_key_options({
-    :format => :der,
-    :type => :dsa
+    :format => :pem,
+    :type => :rsa,
+    :regenerate_if_different => true
   })
   allow_overwrite true
 end
-
 
 aws_security_group 'ref-sg1' do
   vpc 'ref-vpc'
@@ -55,7 +54,6 @@ aws_security_group 'ref-sg1' do
   ]
 end
 
-
 aws_route_table 'ref-public' do
   vpc 'ref-vpc'
   routes '0.0.0.0/0' => :internet_gateway
@@ -64,7 +62,7 @@ end
 aws_subnet 'ref-subnet' do
   vpc 'ref-vpc'
   cidr_block '10.0.0.0/24'
-  availability_zone 'eu-west-1a'
+  availability_zone 'us-west-1a'
   map_public_ip_on_launch true
   route_table 'ref-public'
 end
@@ -78,18 +76,28 @@ machine_image 'ref-machine_image2' do
 end
 
 machine_image 'ref-machine_image3' do
-  machine_options bootstrap_options: { subnet_id: 'ref-subnet', security_group_ids: 'ref-sg1', image_id: 'ref-machine_image1' }
+  machine_options bootstrap_options: {
+    # for some reason, sshing into this host takes 20+ seconds with these enabled
+    #subnet_id: 'ref-subnet',
+    #security_group_ids: 'ref-sg1',
+    image_id: 'ref-machine_image1',
+    instance_type: 't2.small'
+  }
 end
 
 machine_batch do
   machine 'ref-machine1' do
-    machine_options bootstrap_options: { image_id: 'ref-machine_image1', :availability_zone => 'eu-west-1a', instance_type: 'm3.medium' }
+    machine_options bootstrap_options: { image_id: 'ref-machine_image1', :availability_zone => 'us-west-1a', instance_type: 'm3.medium' }
     ohai_hints 'ec2' => { 'a' => 'b' }
     converge false
   end
   machine 'ref-machine2' do
     from_image 'ref-machine_image1'
-    machine_options bootstrap_options: { key_name: 'ref-key-pair', subnet_id: 'ref-subnet', security_group_ids: 'ref-sg1' }
+    machine_options bootstrap_options: {
+      key_name: 'ref-key-pair',
+      #subnet_id: 'ref-subnet',
+      #security_group_ids: 'ref-sg1'
+    }
   end
 end
 
@@ -104,7 +112,7 @@ aws_launch_configuration 'ref-launch-configuration' do
 end
 
 aws_auto_scaling_group 'ref-auto-scaling-group' do
-  availability_zones ['eu-west-1a']
+  availability_zones ['us-west-1a']
   desired_capacity 2
   min_size 1
   max_size 3

--- a/lib/chef/provider/aws_dhcp_options.rb
+++ b/lib/chef/provider/aws_dhcp_options.rb
@@ -1,4 +1,5 @@
 require 'chef/provisioning/aws_driver/aws_provider'
+require 'retryable'
 
 class Chef::Provider::AwsDhcpOptions < Chef::Provisioning::AWSDriver::AWSProvider
   protected
@@ -11,7 +12,9 @@ class Chef::Provider::AwsDhcpOptions < Chef::Provisioning::AWSDriver::AWSProvide
 
     converge_by "create new dhcp_options #{new_resource.name} in #{region}" do
       dhcp_options = new_resource.driver.ec2.dhcp_options.create(options)
-      dhcp_options.tags['Name'] = new_resource.name
+      Retryable.retryable(:tries => 15, :sleep => 1, :on => AWS::EC2::Errors::InvalidDhcpOptionsID::NotFound) do
+        dhcp_options.tags['Name'] = new_resource.name
+      end
       dhcp_options
     end
   end

--- a/lib/chef/provider/aws_security_group.rb
+++ b/lib/chef/provider/aws_security_group.rb
@@ -38,7 +38,7 @@ class Chef::Provider::AwsSecurityGroup < Chef::Provisioning::AWSDriver::AWSProvi
   end
 
   def destroy_aws_object(sg)
-    converge_by "Deleting SG #{new_resource.name} in #{region}" do
+    converge_by "delete #{new_resource.to_s} in #{region}" do
       sg.delete
     end
   end

--- a/lib/chef/provider/aws_subnet.rb
+++ b/lib/chef/provider/aws_subnet.rb
@@ -62,7 +62,7 @@ class Chef::Provider::AwsSubnet < Chef::Provisioning::AWSDriver::AWSProvider
         end
       end
     end
-    converge_by "delete subnet #{new_resource.name} in VPC #{new_resource.vpc} in #{region}" do
+    converge_by "delete #{new_resource.to_s} in VPC #{new_resource.vpc} in #{region}" do
       # If the subnet doesn't exist we can't check state on it - state can only be :pending or :available
       begin
         subnet.delete


### PR DESCRIPTION
There are a few failures with the current ref files:

1. Creating objects in the EU is triggering timeouts trying to ssh into the machines, even they are created successfully.  Updating to faster instances in a local AZ.
1. Machine images are not correctly waiting for their template machines to become terminated before shutting themselves down
1. You cannot delete the main route table or update the main route table except through creating a new main route table.  This means only a `:purge` on the VPC will delete the default route table created and delete the currently assigned route table.