### PR TITLE
Query Ubuntu for current AMI

### DIFF
--- a/chef-provisioning-aws.gemspec
+++ b/chef-provisioning-aws.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'chef-provisioning', '~> 1.0'
   s.add_dependency 'aws-sdk-v1', '>= 1.59.0'
   s.add_dependency 'retryable', '~> 2.0.1'
+  s.add_dependency 'ubuntu_ami', '~> 0.4.1'
 
   # chef-zero is only a development dependency because we leverage its RSpec support
   s.add_development_dependency 'chef-zero', '~> 4.2'


### PR DESCRIPTION
* find AMIs using `ubuntu_ami` gem
* fixes #196 

Does this seem like a reasonable dependency to add? Any changes you'd like to see?