### PR TITLE
Support elb attributes

### DIFF
--- a/docs/examples/ref_full.rb
+++ b/docs/examples/ref_full.rb
@@ -110,6 +110,13 @@ end
 
 load_balancer 'ref-load-balancer' do
   machines [ 'ref-machine2' ]
+  load_balancer_options(
+    attributes: {
+      cross_zone_load_balancing: {
+        enabled: true
+      }
+    }
+  )
 end
 
 aws_launch_configuration 'ref-launch-configuration' do


### PR DESCRIPTION
Add support for load balancer attributes (Adds ability to enable cross-zone load balancing, idle timeouts, etc.) See http://docs.aws.amazon.com/AWSRubySDK/latest/AWS/ELB/Client/V20120601.html#modify_load_balancer_attributes-instance_method for more information. The implementation seems a little wordy but it is just re-using the same terms that the AWS SDK uses. This leaves us with a very verbose implementation:

```
load_balancer 'ref-load-balancer' do
  machines [ 'ref-machine2' ]
  load_balancer_options(
    attributes: {
      cross_zone_load_balancing: {
        enabled: true
      }
    }
  )
end
```

But it works :)