### PR TITLE
Elasticache support

### DIFF
--- a/lib/chef/provider/aws_cache_cluster.rb
+++ b/lib/chef/provider/aws_cache_cluster.rb
@@ -1,0 +1,75 @@
+require 'chef/provisioning/aws_driver/aws_provider'
+
+class Chef::Provider::AwsCacheCluster < Chef::Provisioning::AWSDriver::AWSProvider
+
+  protected
+
+  def create_aws_object
+    converge_by "create new Elasticache Cluster #{new_resource.name} in #{region}" do
+      driver.create_cache_cluster(desired_options)
+    end
+  end
+
+  def update_aws_object(cache_cluster)
+    if update_required?(cache_cluster)
+      converge_by "update Elasticache Cluster #{new_resource.name} in #{region}" do
+        driver.modify_cache_cluster(
+          updatable_options(desired_options).merge(
+            cache_cluster_id: cache_cluster[:cache_cluster_id]
+          )
+        )
+      end
+    end
+  end
+
+  def destroy_aws_object(cache_cluster)
+    converge_by "delete Elasticache Cluster #{new_resource.name} in #{region}" do
+      driver.delete_cache_cluster(
+        cache_cluster_id: cache_cluster[:cache_cluster_id]
+      )
+    end
+  end
+
+  private
+
+  def driver
+    new_resource.driver.elasticache
+  end
+
+  def desired_options
+    @desired_options ||= begin
+      options = {}
+      options[:cache_cluster_id] = new_resource.cluster_name
+      options[:num_cache_nodes] = new_resource.number_nodes
+      options[:cache_node_type] = new_resource.node_type
+      options[:engine] = new_resource.engine
+      options[:az_mode] = new_resource.az_mode if new_resource.az_mode
+      options[:preferred_availability_zone] =
+        new_resource.preferred_availability_zone if new_resource.preferred_availability_zone
+      options[:preferred_availability_zones] =
+        new_resource.preferred_availability_zones if new_resource.preferred_availability_zones
+      options[:engine_version] = new_resource.engine_version
+      options[:cache_subnet_group_name] =
+        new_resource.subnet_group_name if new_resource.subnet_group_name
+      options[:security_group_ids] = new_resource.security_groups
+      AWSResource.lookup_options(options, resource: new_resource)
+    end
+  end
+
+  def updatable_options(options)
+    updatable = [:security_groups, :num_cache_nodes, :engine_version]
+    options.delete_if { |option, _value| !updatable.include?(option) }
+  end
+
+  def update_required?(cache_cluster)
+    current_sg_ids = cache_cluster[:security_groups].map { |sg| sg[:security_group_id] }.sort
+
+    if desired_options[:security_group_ids].sort != current_sg_ids ||
+      desired_options[:num_cache_nodes] != cache_cluster[:num_cache_nodes] ||
+      desired_options[:engine_version] != cache_cluster[:engine_version]
+      true
+    else
+      false
+    end
+  end
+end

--- a/lib/chef/provider/aws_cache_replication_group.rb
+++ b/lib/chef/provider/aws_cache_replication_group.rb
@@ -1,0 +1,49 @@
+require 'chef/provisioning/aws_driver/aws_provider'
+
+class Chef::Provider::AwsCacheReplicationGroup < Chef::Provisioning::AWSDriver::AWSProvider
+
+  protected
+
+  def create_aws_object
+    converge_by "create new Elasticache Replication Group #{new_resource.name} in #{region}" do
+      driver.create_replication_group(desired_options)
+    end
+  end
+
+  def update_aws_object(cache_replication_group)
+    Chef::Log.warn('Updating Elasticache Replication Groups is currently unsupported')
+  end
+
+  def destroy_aws_object(cache_replication_group)
+    converge_by "delete Elasticache Replication group #{new_resource.name} in #{region}" do
+      driver.delete_replication_group(
+        replication_group_id: cache_replication_group[:replication_group_id]
+      )
+    end
+  end
+
+  private
+
+  def driver
+    new_resource.driver.elasticache
+  end
+
+  def desired_options
+    @desired_options ||= begin
+      options = {}
+      options[:replication_group_id] = new_resource.group_name
+      options[:replication_group_description] = new_resource.description
+      options[:automatic_failover_enabled] = new_resource.automatic_failover
+      options[:num_cache_clusters] = new_resource.number_cache_clusters
+      options[:cache_node_type] = new_resource.node_type
+      options[:engine] = new_resource.engine
+      options[:engine_version] = new_resource.engine_version
+      options[:preferred_cache_cluster_a_zs] =
+        new_resource.preferred_availability_zones if new_resource.preferred_availability_zones
+      options[:cache_subnet_group_name] =
+        new_resource.subnet_group_name if new_resource.subnet_group_name
+      options[:security_group_ids] = new_resource.security_groups
+      AWSResource.lookup_options(options, resource: new_resource)
+    end
+  end
+end

--- a/lib/chef/provider/aws_cache_subnet_group.rb
+++ b/lib/chef/provider/aws_cache_subnet_group.rb
@@ -1,0 +1,60 @@
+require 'chef/provisioning/aws_driver/aws_provider'
+
+class Chef::Provider::AwsCacheSubnetGroup < Chef::Provisioning::AWSDriver::AWSProvider
+
+  protected
+
+  def create_aws_object
+    converge_by "create new Elasticache Subnet Group #{new_resource.name} in #{region}" do
+      driver.create_cache_subnet_group(desired_options)
+    end
+  end
+
+  def update_aws_object(cache_subnet_group)
+    if update_required?(cache_subnet_group)
+      converge_by "update Elasticache Subnet Group #{new_resource.name} in #{region}" do
+        driver.modify_cache_subnet_group(desired_options)
+      end
+    end
+  end
+
+  def destroy_aws_object(cache_subnet_group)
+    converge_by "delete Elasticache Subnet Group #{new_resource.name} in #{region}" do
+      driver.delete_cache_subnet_group(
+        cache_subnet_group_name: cache_subnet_group[:cache_subnet_group_name]
+      )
+    end
+  end
+
+  private
+
+  def driver
+    new_resource.driver.elasticache
+  end
+
+  def update_cache_subnet_group
+    new_resource.driver.elasticache.modify_cache_subnet_group(desired_options)
+  end
+
+  def desired_options
+    @desired_options ||= begin
+      options = {}
+      options[:cache_subnet_group_name] = new_resource.group_name
+      options[:cache_subnet_group_description] = new_resource.description
+      options[:subnet_ids] = new_resource.subnets
+      AWSResource.lookup_options(options, resource: new_resource)
+    end
+  end
+
+  def update_required?(cache_subnet_group)
+    current_subnet_ids = cache_subnet_group[:subnets]
+                           .map { |subnet| subnet[:subnet_identifier] }.sort
+    current_description = cache_subnet_group[:cache_subnet_group_description]
+    if new_resource.description != current_description ||
+      desired_options[:subnet_ids].sort != current_subnet_ids
+      true
+    else
+      false
+    end
+  end
+end

--- a/lib/chef/provisioning/aws_driver.rb
+++ b/lib/chef/provisioning/aws_driver.rb
@@ -2,6 +2,9 @@ require 'chef/provisioning'
 require 'chef/provisioning/aws_driver/driver'
 
 require "chef/resource/aws_auto_scaling_group"
+require "chef/resource/aws_cache_cluster"
+require "chef/resource/aws_cache_replication_group"
+require "chef/resource/aws_cache_subnet_group"
 require "chef/resource/aws_dhcp_options"
 require "chef/resource/aws_ebs_volume"
 require "chef/resource/aws_eip_address"

--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -522,6 +522,10 @@ EOD
       @elb ||= AWS::ELB.new(config: aws_config)
     end
 
+    def elasticache
+      @elasticache ||= AWS::ElastiCache::Client.new(config: aws_config)
+    end
+
     def iam
       @iam ||= AWS::IAM.new(config: aws_config)
     end

--- a/lib/chef/resource/aws_cache_cluster.rb
+++ b/lib/chef/resource/aws_cache_cluster.rb
@@ -1,0 +1,37 @@
+require 'chef/provisioning/aws_driver/aws_resource'
+require 'chef/resource/aws_security_group'
+
+class Chef::Resource::AwsCacheCluster < Chef::Provisioning::AWSDriver::AWSResource
+  # Note: There isn't actually an SDK class for Elasticache.
+  aws_sdk_type AWS::ElastiCache
+
+  # See http://docs.aws.amazon.com/AWSRubySDK/latest/AWS/ElastiCache/Client/V20140930.html#create_cache_cluster-instance_method
+  # for information on possible values for each attribute. Values are passed
+  # straight through to AWS, with the exception of security_groups, which
+  # may contain a reference to a Chef aws_security_group resource.
+  attribute :cluster_name, kind_of: String, name_attribute: true
+  attribute :az_mode, kind_of: String
+  attribute :preferred_availability_zone, kind_of: String
+  attribute :preferred_availability_zones,
+            kind_of: [ String, Array ],
+            coerce: proc { |v| [v].flatten }
+  attribute :number_nodes, kind_of: Integer, default: 1
+  attribute :node_type, kind_of: String, required: true
+  attribute :engine, kind_of: String, required: true
+  attribute :engine_version, kind_of: String, required: true
+  attribute :subnet_group_name, kind_of: String
+  attribute :security_groups,
+            kind_of: [ String, Array, AwsSecurityGroup, AWS::EC2::SecurityGroup ],
+            required: true,
+            coerce: proc { |v| [v].flatten }
+
+  def aws_object
+    begin
+      driver.elasticache
+        .describe_cache_clusters(cache_cluster_id: cluster_name)
+        .data[:cache_clusters].first
+    rescue AWS::ElastiCache::Errors::CacheClusterNotFound
+      nil
+    end
+  end
+end

--- a/lib/chef/resource/aws_cache_replication_group.rb
+++ b/lib/chef/resource/aws_cache_replication_group.rb
@@ -1,0 +1,37 @@
+require 'chef/provisioning/aws_driver/aws_resource'
+require 'chef/resource/aws_security_group'
+
+class Chef::Resource::AwsCacheReplicationGroup < Chef::Provisioning::AWSDriver::AWSResource
+  # Note: There isn't actually an SDK class for Elasticache.
+  aws_sdk_type AWS::ElastiCache
+
+  # See http://docs.aws.amazon.com/AWSRubySDK/latest/AWS/ElastiCache/Client/V20140930.html#create_replication_group-instance_method
+  # for information on possible values for each attribute. Values are passed
+  # straight through to AWS, with the exception of security_groups, which
+  # may contain a reference to a Chef aws_security_group resource.
+  attribute :group_name, kind_of: String, name_attribute: true
+  attribute :description, kind_of: String, required: true
+  attribute :automatic_failover, kind_of: [TrueClass, FalseClass], default: false
+  attribute :number_cache_clusters, kind_of: Integer, default: 2
+  attribute :node_type, kind_of: String, required: true
+  attribute :engine, kind_of: String, required: true
+  attribute :engine_version, kind_of: String, required: true
+  attribute :subnet_group_name, kind_of: String
+  attribute :security_groups,
+            kind_of: [ String, Array, AwsSecurityGroup, AWS::EC2::SecurityGroup ],
+            required: true,
+            coerce: proc { |v| [v].flatten }
+  attribute :preferred_availability_zones,
+            kind_of: [ String, Array ],
+            coerce: proc { |v| [v].flatten }
+
+  def aws_object
+    begin
+      driver.elasticache
+        .describe_replication_groups(replication_group_id: group_name)
+        .data[:replication_groups].first
+    rescue AWS::ElastiCache::Errors::ReplicationGroupNotFoundFault
+      nil
+    end
+  end
+end

--- a/lib/chef/resource/aws_cache_subnet_group.rb
+++ b/lib/chef/resource/aws_cache_subnet_group.rb
@@ -1,0 +1,28 @@
+require 'chef/provisioning/aws_driver/aws_resource'
+require 'chef/resource/aws_subnet'
+
+class Chef::Resource::AwsCacheSubnetGroup < Chef::Provisioning::AWSDriver::AWSResource
+  # Note: There isn't actually an SDK class for Elasticache.
+  aws_sdk_type AWS::ElastiCache, id: :group_name
+
+  # See http://docs.aws.amazon.com/AWSRubySDK/latest/AWS/ElastiCache/Client/V20140930.html#create_cache_subnet_group-instance_method
+  # for information on possible values for each attribute. Values are passed
+  # straight through to AWS, with the exception of subnets, which
+  # may contain a reference to a Chef aws_subnet resource.
+  attribute :group_name, kind_of: String, name_attribute: true
+  attribute :description, kind_of: String, required: true
+  attribute :subnets,
+            kind_of: [ String, Array, AwsSubnet, AWS::EC2::Subnet ],
+            required: true,
+            coerce: proc { |v| [v].flatten }
+
+  def aws_object
+    begin
+      driver.elasticache
+        .describe_cache_subnet_groups(cache_subnet_group_name: group_name)
+        .data[:cache_subnet_groups].first
+    rescue AWS::ElastiCache::Errors::CacheSubnetGroupNotFoundFault
+      nil
+    end
+  end
+end

--- a/spec/integration/aws_cache_subnet_group_spec.rb
+++ b/spec/integration/aws_cache_subnet_group_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe Chef::Resource::AwsCacheSubnetGroup do
+  extend AWSSupport
+
+  when_the_chef_12_server "exists", organization: 'foo', server_scope: :context do
+    with_aws "with a VPC with an internet gateway and subnet" do
+      aws_vpc "test_vpc" do
+        cidr_block '10.0.0.0/24'
+        internet_gateway true
+      end
+
+      aws_subnet "test_subnet" do
+        vpc 'test_vpc'
+        availability_zone 'us-east-1a'
+        cidr_block "10.0.0.0/24"
+      end
+
+      it "aws_cache_subnet_group 'test-subnet-group' creates a cache subnet group" do
+        expect_recipe {
+          aws_cache_subnet_group 'test-subnet-group' do
+            description 'Test Subnet Group'
+            subnets [ 'test_subnet' ]
+          end
+        }.to create_an_aws_cache_subnet_group('test-subnet-group',
+          subnets: [
+            { subnet_identifier: test_subnet.aws_object.id }
+          ]
+        ).and be_idempotent
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #207 - Support for defining an Elasticache cluster (Redis/Memcache)

- [x] Subnet group
* ~~Security group~~
- [x] Cache cluster
- [x] Replication group (Required for redis clustering)

Edit: Security groups aren't necessary. Only if creating a cache cluster outside of a VPC

Like RDS, Elasticache has a one to many relationship between subnet/security groups and the actual cache cluster. Thus, they must be separate resources. Unfortunately it is not possible to re-use regular VPC subnet/security groups.

Elasticache is kind of a beast because there's no SDK resource class, only a client. This implementation works for subnet groups just fine. Hopefully we can carry that in to the security groups and cache cluster, too. 

Input is greatly appreciated. I decided to go w/ `cache` in the resource names as opposed to `elasticache` to keep it from being too wordy. 

I will add some tests before I'm done.

Subnet group resource example (vpc is implicit based on subnets specified):
```
aws_cache_subnet_group 'test-ec' do
  description 'My awesome group'
  subnets [ 'public-test' ]
end
```

Cache cluster resource example:
```
aws_cache_cluster 'my-cluster-mem' do
  number_nodes 2
  node_type 'cache.t2.micro'
  engine 'memcached'
  engine_version '1.4.14'
  security_groups ['my_security_group']
  subnet_group_name 'test-ec'
end
```