### PR TITLE
wait_until_taggable for VPC's, fixes #218

### DIFF
--- a/lib/chef/provider/aws_vpc.rb
+++ b/lib/chef/provider/aws_vpc.rb
@@ -36,6 +36,14 @@ class Chef::Provider::AwsVpc < Chef::Provisioning::AWSDriver::AWSProvider
 
   protected
 
+  #
+  # If this object is either in pending or running state, then it's taggable
+  #
+  def taggable?
+    status == :pending || status == :running
+  end
+
+
   def create_aws_object
     options = { }
     options[:instance_tenancy] = new_resource.instance_tenancy if new_resource.instance_tenancy
@@ -43,6 +51,7 @@ class Chef::Provider::AwsVpc < Chef::Provisioning::AWSDriver::AWSProvider
     converge_by "create new VPC #{new_resource.name} in #{region}" do
       vpc = new_resource.driver.ec2.vpcs.create(new_resource.cidr_block, options)
       vpc.tags['Name'] = new_resource.name
+      new_resource.wait_until_taggable
       vpc
     end
   end

--- a/lib/chef/provisioning/aws_driver/aws_resource.rb
+++ b/lib/chef/provisioning/aws_driver/aws_resource.rb
@@ -60,6 +60,23 @@ class AWSResource < Chef::Provisioning::AWSDriver::SuperLWRP
     raise NotImplementedError, :aws_object
   end
 
+
+  #
+  # Is this object ready to be tagged?
+  #
+  def taggable?
+    false
+  end
+
+  #
+  # Wait until this object.taggable? returns true
+  #
+  def wait_until_taggable()
+    Retryable.retryable(:tries => 12, :sleep => 5, :on => [AWS::EC2::Errors::InvalidInstanceID::NotFound, TimeoutError]) do
+      raise TimeoutError unless taggable?
+    end
+  end
+
   #
   # Look up an AWS options list, translating standard names using the appropriate
   # classes.

--- a/lib/chef/provisioning/aws_driver/aws_resource_with_entry.rb
+++ b/lib/chef/provisioning/aws_driver/aws_resource_with_entry.rb
@@ -24,6 +24,13 @@ class Chef::Provisioning::AWSDriver::AWSResourceWithEntry < Chef::Provisioning::
   end
 
   #
+  # Override the default implementation to be true
+  #
+  def taggable?
+    true
+  end
+
+  #
   # Save the ID of this object to Chef.
   #
   # @param aws_object [AWS::EC2::Core] The AWS object containing the ID.

--- a/lib/chef/resource/aws_eip_address.rb
+++ b/lib/chef/resource/aws_eip_address.rb
@@ -43,6 +43,13 @@ class Chef::Resource::AwsEipAddress < Chef::Provisioning::AWSDriver::AWSResource
     result && result.exists? ? result : nil
   end
 
+  #
+  # this object isn't taggable even though the base class says it is
+  #
+  def taggable?
+    false
+  end
+
   def action(*args)
     # Backcompat for associate and disassociate
     if args == [ :associate ]


### PR DESCRIPTION
Fixes #218

Manually tested with the recipe below, isn't that sad?
```
require 'chef/provisioning/aws_driver'

with_driver 'aws::eu-west-1'
aws_vpc "foo_vpc_pr" do
  cidr_block "10.0.0.0/24"
  internet_gateway true
  main_routes '0.0.0.0/0' => :internet_gateway
  aws_tags :friday => "foo_test"
end
```