### PR TITLE
yard doc first pass on elasticache code

### DIFF
--- a/docs/examples/ref_elasticache.rb
+++ b/docs/examples/ref_elasticache.rb
@@ -1,0 +1,31 @@
+require 'chef/provisioning/aws_driver'
+with_driver 'aws::us-east-1'
+
+aws_vpc 'test' do
+  cidr_block "10.0.0.0/24"
+end
+
+aws_subnet "public-test" do
+  vpc 'test'
+  availability_zone 'us-east-1a'
+  cidr_block "10.0.0.0/24"
+end
+
+aws_cache_subnet_group 'test-ec' do
+  description 'My awesome group'
+  subnets [ 'public-test' ]
+end
+
+aws_security_group 'test-sg' do
+  vpc 'test'
+end
+
+aws_cache_cluster 'my-cluster-mem' do
+  az_mode 'single-az'
+  number_nodes 2
+  node_type 'cache.t2.micro'
+  engine 'memcached'
+  engine_version '1.4.14'
+  security_groups ['test-sg']
+  subnet_group_name 'test-ec'
+end

--- a/lib/chef/resource/aws_cache_cluster.rb
+++ b/lib/chef/resource/aws_cache_cluster.rb
@@ -21,7 +21,7 @@ class Chef::Resource::AwsCacheCluster < Chef::Provisioning::AWSDriver::AWSResour
 
   # Availability Zone
   #
-  # @param :az_mode [String] availability zone of the cache cluster
+  # @param :az_mode [String] Specifies whether the nodes in this Memcached node group are created in a single Availability Zone or created across multiple Availability Zones in the cluster's region. This parameter is only supported for Memcached cache clusters. If the AZMode and PreferredAvailabilityZones are not specified, ElastiCache assumes single-az mode.
   attribute :az_mode, kind_of: String
 
   # Preferred Availability Zone

--- a/lib/chef/resource/aws_cache_cluster.rb
+++ b/lib/chef/resource/aws_cache_cluster.rb
@@ -1,6 +1,9 @@
 require 'chef/provisioning/aws_driver/aws_resource'
 require 'chef/resource/aws_security_group'
 
+# AWS Elasticache Cluster
+#
+# @see http://docs.aws.amazon.com/AWSRubySDK/latest/AWS/ElastiCache/Client/V20140930.html#create_cache_cluster-instance_method
 class Chef::Resource::AwsCacheCluster < Chef::Provisioning::AWSDriver::AWSResource
   # Note: There isn't actually an SDK class for Elasticache.
   aws_sdk_type AWS::ElastiCache
@@ -9,17 +12,59 @@ class Chef::Resource::AwsCacheCluster < Chef::Provisioning::AWSDriver::AWSResour
   # for information on possible values for each attribute. Values are passed
   # straight through to AWS, with the exception of security_groups, which
   # may contain a reference to a Chef aws_security_group resource.
+
+
+  # Cluster Name
+  #
+  # @param :cluster_name [String] unique name for a cluster
   attribute :cluster_name, kind_of: String, name_attribute: true
+
+  # Availability Zone
+  #
+  # @param :az_mode [String] availability zone of the cache cluster
   attribute :az_mode, kind_of: String
+
+  # Preferred Availability Zone
+  #
+  # @param :preferred_availability_zone [String] preferred availability zone of the cache cluster
   attribute :preferred_availability_zone, kind_of: String
+
+  # Preferred Availability Zones
+  #
+  # @param :preferred_availability_zones [String, Array] One or more preferred availability zones
   attribute :preferred_availability_zones,
             kind_of: [ String, Array ],
             coerce: proc { |v| [v].flatten }
+
+
+  # Number of Nodes
+  #
+  # @param :number_nodes [Integer] Number of nodes in the cache
   attribute :number_nodes, kind_of: Integer, default: 1
+
+  # Node type
+  #
+  # @param :node_type [String] AWS node type for each cache cluster node
   attribute :node_type, kind_of: String, required: true
+
+  # Engine
+  #
+  # @param :engine [String] Valid values are `memcached` or `redis`
   attribute :engine, kind_of: String, required: true
+
+  # Engine Version
+  #
+  # @param :engine_version [String] Valid values are `memcached` or `redis`
   attribute :engine_version, kind_of: String, required: true
+
+  # Subnet Group Name
+  #
+  # @param :subnet_group_name [String] Cache cluster subnet group
   attribute :subnet_group_name, kind_of: String
+
+  # Security Groups
+  #
+  # @param :security_groups [String, Array, AwsSecurityGroup, AWS::EC2::SecurityGroup] one or more VPC security groups associated with the cache cluster.
   attribute :security_groups,
             kind_of: [ String, Array, AwsSecurityGroup, AWS::EC2::SecurityGroup ],
             required: true,

--- a/lib/chef/resource/aws_cache_cluster.rb
+++ b/lib/chef/resource/aws_cache_cluster.rb
@@ -59,7 +59,7 @@ class Chef::Resource::AwsCacheCluster < Chef::Provisioning::AWSDriver::AWSResour
 
   # Subnet Group Name
   #
-  # @param :subnet_group_name [String] Cache cluster subnet group
+  # @param :subnet_group_name [String] Cache cluster aws_cache_subnet_group
   attribute :subnet_group_name, kind_of: String
 
   # Security Groups

--- a/lib/chef/resource/aws_cache_cluster.rb
+++ b/lib/chef/resource/aws_cache_cluster.rb
@@ -54,7 +54,7 @@ class Chef::Resource::AwsCacheCluster < Chef::Provisioning::AWSDriver::AWSResour
 
   # Engine Version
   #
-  # @param :engine_version [String] Valid values are `memcached` or `redis`
+  # @param :engine_version [String] The version number of the cache engine to be used for this cache cluster. 
   attribute :engine_version, kind_of: String, required: true
 
   # Subnet Group Name

--- a/lib/chef/resource/aws_cache_replication_group.rb
+++ b/lib/chef/resource/aws_cache_replication_group.rb
@@ -1,6 +1,8 @@
 require 'chef/provisioning/aws_driver/aws_resource'
 require 'chef/resource/aws_security_group'
 
+# AWS Elasticache Replication Group
+# @see See http://docs.aws.amazon.com/AWSRubySDK/latest/AWS/ElastiCache/Client/V20140930.html#create_replication_group-instance_method
 class Chef::Resource::AwsCacheReplicationGroup < Chef::Provisioning::AWSDriver::AWSResource
   # Note: There isn't actually an SDK class for Elasticache.
   aws_sdk_type AWS::ElastiCache
@@ -9,18 +11,58 @@ class Chef::Resource::AwsCacheReplicationGroup < Chef::Provisioning::AWSDriver::
   # for information on possible values for each attribute. Values are passed
   # straight through to AWS, with the exception of security_groups, which
   # may contain a reference to a Chef aws_security_group resource.
+
+  # Group Name
+  #
+  # @param :group_name [String] Elasticache replication group name.
   attribute :group_name, kind_of: String, name_attribute: true
+
+  # Replication group description
+  #
+  # @param :description [String] Elasticache replication group description.
   attribute :description, kind_of: String, required: true
+
+  # Automatic failover
+  #
+  # @param :automatic_failover [Boolean] Whether a read replica will be automatically promoted to read/write primary if the existing primary encounters a failure.
   attribute :automatic_failover, kind_of: [TrueClass, FalseClass], default: false
+
+  # Number of cache clusters
+  #
+  # @param :number_cache_clusters [Integer] Number of cache clusters.
   attribute :number_cache_clusters, kind_of: Integer, default: 2
+
+  # Node type
+  #
+  # @param :node_type [String] AWS node type for each replication group.
   attribute :node_type, kind_of: String, required: true
+
+  # Engine
+  #
+  # @param :engine [String] Valid values are `memcached` or `redis`.
   attribute :engine, kind_of: String, required: true
+
+  # Engine Version
+  #
+  # @param :engine_version [String] The version number of the cache engine.
   attribute :engine_version, kind_of: String, required: true
+
+  # Subnet group name
+  #
+  # @param :subnet_group_name [String] Cache cluster subnet group.
   attribute :subnet_group_name, kind_of: String
+
+  # Security Groups
+  #
+  # @param
   attribute :security_groups,
             kind_of: [ String, Array, AwsSecurityGroup, AWS::EC2::SecurityGroup ],
             required: true,
             coerce: proc { |v| [v].flatten }
+
+  # Group Name
+  #
+  # @param
   attribute :preferred_availability_zones,
             kind_of: [ String, Array ],
             coerce: proc { |v| [v].flatten }

--- a/lib/chef/resource/aws_cache_replication_group.rb
+++ b/lib/chef/resource/aws_cache_replication_group.rb
@@ -49,7 +49,7 @@ class Chef::Resource::AwsCacheReplicationGroup < Chef::Provisioning::AWSDriver::
 
   # Subnet group name
   #
-  # @param :subnet_group_name [String] Cache cluster subnet group.
+  # @param :subnet_group_name [String] Cache cluster aws_cache_subnet_group.
   attribute :subnet_group_name, kind_of: String
 
   # Security Groups

--- a/lib/chef/resource/aws_cache_subnet_group.rb
+++ b/lib/chef/resource/aws_cache_subnet_group.rb
@@ -1,6 +1,8 @@
 require 'chef/provisioning/aws_driver/aws_resource'
 require 'chef/resource/aws_subnet'
 
+# AWS Elasticache Subnet Group
+# @see http://docs.aws.amazon.com/AWSRubySDK/latest/AWS/ElastiCache/Client/V20140930.html#create_cache_subnet_group-instance_method
 class Chef::Resource::AwsCacheSubnetGroup < Chef::Provisioning::AWSDriver::AWSResource
   # Note: There isn't actually an SDK class for Elasticache.
   aws_sdk_type AWS::ElastiCache, id: :group_name
@@ -9,8 +11,20 @@ class Chef::Resource::AwsCacheSubnetGroup < Chef::Provisioning::AWSDriver::AWSRe
   # for information on possible values for each attribute. Values are passed
   # straight through to AWS, with the exception of subnets, which
   # may contain a reference to a Chef aws_subnet resource.
+
+  # Group Name
+  #
+  # @param :group_name [String] The name of the cache subnet group to be used for the replication group.
   attribute :group_name, kind_of: String, name_attribute: true
+
+  # Description
+  #
+  # @param :description [String] Subnet group description.
   attribute :description, kind_of: String, required: true
+
+  # Subnets
+  #
+  # @param :subnets [ String, Array, AwsSubnet, AWS::EC2::Subnet ] One or more subnets in the subnet group.
   attribute :subnets,
             kind_of: [ String, Array, AwsSubnet, AWS::EC2::Subnet ],
             required: true,


### PR DESCRIPTION
It feels like the Yard docs are repetitive, but let's see what docs we can generate with them.

This also include `ref_elasticache.rb`. `ref_full.rb` + additional specs coming in another PR.