### PR TITLE
Fix security group rule comparison

### DIFF
--- a/lib/chef/provider/aws_security_group.rb
+++ b/lib/chef/provider/aws_security_group.rb
@@ -148,7 +148,7 @@ class Chef::Provider::AwsSecurityGroup < Chef::Provisioning::AWSDriver::AWSProvi
     actual_rules = {}
     actual_rules_list.each do |rule|
       port_range = {
-        port_range: rule[:from_port] ? rule[:from_port]..rule[:to_port] : nil,
+        port_range: rule[:from_port] ? rule[:from_port]..rule[:to_port] : -1..-1,
         protocol: rule[:ip_protocol].to_s.to_sym
       }
       add_rule(actual_rules, [ port_range ], rule[:groups]) if rule[:groups]

--- a/spec/integration/aws_security_group_spec.rb
+++ b/spec/integration/aws_security_group_spec.rb
@@ -90,6 +90,22 @@ describe Chef::Resource::AwsSecurityGroup do
           ip_permissions_list_egress: [{groups: [], ip_ranges: [{cidr_ip: "0.0.0.0/0"}], ip_protocol: "tcp", from_port: 22, to_port: 22 }]
         ).and be_idempotent
       end
+
+      it "aws_security_group 'test_sg' with inbound and outbound rules allowing all ports works when protocol specified" do
+        expect_recipe {
+        aws_security_group 'test_sg' do
+          vpc 'test_vpc'
+          inbound_rules('0.0.0.0/0' => { port_range: -1..-1, protocol: -1 })
+          outbound_rules({ port_range: -1..-1, protocol: -1 } => '0.0.0.0/0')
+        end
+        }.to create_an_aws_security_group('test_sg',
+          vpc_id: test_vpc.aws_object.id,
+          ip_permissions_list: [
+            { groups: [], ip_ranges: [{cidr_ip: "0.0.0.0/0"}],  ip_protocol: "-1"}
+          ],
+          ip_permissions_list_egress: [{ groups: [], ip_ranges: [{cidr_ip: "0.0.0.0/0"}],  ip_protocol: "-1"}]
+        ).and be_idempotent
+      end
     end
 
     with_aws "when narrowing from multiple VPCs" do


### PR DESCRIPTION
This fixes a very specific bug in `aws_security_group` rule comparison. If a protocol is specified, such as `protocol: -1` then `port_range` comparison would fail. This is because the desired rule would specify `port_range: -1..-1` while the actual rule would come back as `port_range: nil`. 

This is easily resolved by setting `port_range` to `-1..-1` in the absence of a specific `rule[:from_port]`. I also added a test that should catch this in the future. I wasn't able to explicitly test for the output of `port_range` since it's not available in the `ip_permission_list`. However, by just having the test in here we will get the following error if this happens again:

```
     AWS::EC2::Errors::InvalidPermission::Duplicate:
       aws_security_group[test_sg] (basic_chef_client::block line 96) had an error: AWS::EC2::Errors::InvalidPermission::Duplicate: the specified rule "peer: 0.0.0.0/0, ALL, ALLOW" already exists
```

Addresses the issue described in https://github.com/chef/chef-provisioning-aws/issues/154#issuecomment-112078637 (issue comment only - does not address the original intent of the issue report)