### PR TITLE
use wait_for_state before tagging VPC's, fixes #218

### DIFF
--- a/lib/chef/provider/aws_vpc.rb
+++ b/lib/chef/provider/aws_vpc.rb
@@ -42,6 +42,7 @@ class Chef::Provider::AwsVpc < Chef::Provisioning::AWSDriver::AWSProvider
 
     converge_by "create new VPC #{new_resource.name} in #{region}" do
       vpc = new_resource.driver.ec2.vpcs.create(new_resource.cidr_block, options)
+      wait_for_state(vpc, [:available])
       vpc.tags['Name'] = new_resource.name
       vpc
     end

--- a/spec/integration/aws_vpc_spec.rb
+++ b/spec/integration/aws_vpc_spec.rb
@@ -23,6 +23,22 @@ describe Chef::Resource::AwsVpc do
           ).and be_idempotent
         end
 
+        it "aws_vpc 'vpc' with cidr_block '10.0.0.0/24' creates a VPC with tags" do
+          expect_recipe {
+            aws_vpc 'test_vpc_2' do
+              cidr_block '10.0.0.0/24'
+              aws_tags :foo => :bar
+            end
+          }.to create_an_aws_vpc('test_vpc_2',
+            cidr_block: '10.0.0.0/24',
+            instance_tenancy: :default,
+            state: :available,
+            internet_gateway: nil
+          ).and have_aws_vpc_tags('test_vpc_2',
+                                  {"foo" => "bar"}
+          ).and be_idempotent
+        end
+
         it "aws_vpc 'vpc' with all attributes creates a VPC" do
           expect_recipe {
             aws_vpc 'test_vpc' do


### PR DESCRIPTION
Some AWS objects don't have a "status" value, but a "state" (such as an AWS VPC). This PR adds a `wait_for_state` method in `AwsProvider`. This method is called before trying to tag a VPC to prevent a race when the VPC may be in `pending` state.

fixes https://github.com/chef/chef-provisioning-aws/issues/218