### PR TITLE
Updating for Chef 12.4.x, fixes #240

### DIFF
--- a/lib/chef/provider/aws_key_pair.rb
+++ b/lib/chef/provider/aws_key_pair.rb
@@ -168,7 +168,7 @@ class Chef::Provider::AwsKeyPair < Chef::Provisioning::AWSDriver::AWSProvider
 
     current_key_pair = new_resource.aws_object
     if current_key_pair
-      @current_fingerprint = current_key_pair ? current_key_pair.fingerprint : nil
+      @current_fingerprint = current_key_pair.fingerprint
     else
       current_resource.action :destroy
     end

--- a/lib/chef/provisioning/aws_driver/aws_resource.rb
+++ b/lib/chef/provisioning/aws_driver/aws_resource.rb
@@ -25,8 +25,13 @@ class AWSResource < Chef::Provisioning::AWSDriver::SuperLWRP
       super
     end
   end
-  def action=(value)
-    action(value)
+
+  # In Chef < 12.4 we need to define this method.  In > 12.4 this method is
+  # already defined for us so we don't need to overwrite it.
+  unless defined?(:action=)
+    def action=(value)
+      action(value)
+    end
   end
 
   #

--- a/spec/integration/aws_cache_subnet_group_spec.rb
+++ b/spec/integration/aws_cache_subnet_group_spec.rb
@@ -12,7 +12,6 @@ describe Chef::Resource::AwsCacheSubnetGroup do
 
       aws_subnet "test_subnet" do
         vpc 'test_vpc'
-        availability_zone 'us-east-1a'
         cidr_block "10.0.0.0/24"
       end
 

--- a/spec/integration/aws_key_pair_spec.rb
+++ b/spec/integration/aws_key_pair_spec.rb
@@ -10,11 +10,11 @@ describe Chef::Resource::AwsKeyPair do
       end
 
       it "aws_key_pair 'test_key_pair' creates a key pair" do
-        expect_recipe {
+        expect(recipe {
           aws_key_pair 'test_key_pair' do
             private_key_options format: :der, type: :rsa
           end
-        }.to create_an_aws_key_pair('test_key_pair').and be_idempotent
+        }).to create_an_aws_key_pair('test_key_pair').and be_idempotent
       end
     end
   end


### PR DESCRIPTION
Fixes #240 

It broke some resource hacks we were doing.  I ran the tests and they pass with both 12.3 and 12.4

\cc @fnichol @randomcamel 