### PR TITLE
Adding exponential backoff when checking taggable status

### DIFF
--- a/lib/chef/provider/aws_dhcp_options.rb
+++ b/lib/chef/provider/aws_dhcp_options.rb
@@ -12,7 +12,7 @@ class Chef::Provider::AwsDhcpOptions < Chef::Provisioning::AWSDriver::AWSProvide
 
     converge_by "create new dhcp_options #{new_resource.name} in #{region}" do
       dhcp_options = new_resource.driver.ec2.dhcp_options.create(options)
-      Retryable.retryable(:tries => 15, :sleep => lambda { |n| 2**n }, :on => AWS::EC2::Errors::InvalidDhcpOptionsID::NotFound) do
+      retry_with_backoff(AWS::EC2::Errors::InvalidDhcpOptionsID::NotFound) do
         dhcp_options.tags['Name'] = new_resource.name
       end
       dhcp_options

--- a/lib/chef/provider/aws_dhcp_options.rb
+++ b/lib/chef/provider/aws_dhcp_options.rb
@@ -12,7 +12,7 @@ class Chef::Provider::AwsDhcpOptions < Chef::Provisioning::AWSDriver::AWSProvide
 
     converge_by "create new dhcp_options #{new_resource.name} in #{region}" do
       dhcp_options = new_resource.driver.ec2.dhcp_options.create(options)
-      Retryable.retryable(:tries => 15, :sleep => 1, :on => AWS::EC2::Errors::InvalidDhcpOptionsID::NotFound) do
+      Retryable.retryable(:tries => 15, :sleep => lambda { |n| 2**n }, :on => AWS::EC2::Errors::InvalidDhcpOptionsID::NotFound) do
         dhcp_options.tags['Name'] = new_resource.name
       end
       dhcp_options

--- a/lib/chef/provider/aws_ebs_volume.rb
+++ b/lib/chef/provider/aws_ebs_volume.rb
@@ -36,7 +36,10 @@ class Chef::Provider::AwsEbsVolume < Chef::Provisioning::AWSDriver::AWSProvider
     volume = nil
     converge_by "create new #{new_resource} in #{region}" do
       volume = new_resource.driver.ec2.volumes.create(initial_options)
-      volume.tags['Name'] = new_resource.name
+      retry_with_backoff(AWS::EC2::Errors::InvalidVolumeID::NotFound) do
+        volume.tags['Name'] = new_resource.name
+      end
+      volume
     end
 
     converge_by "wait for new #{new_resource} in #{region} to become available" do

--- a/lib/chef/provider/aws_network_acl.rb
+++ b/lib/chef/provider/aws_network_acl.rb
@@ -20,7 +20,7 @@ class Chef::Provider::AwsNetworkAcl < Chef::Provisioning::AWSDriver::AWSProvider
       Chef::Log.debug("VPC: #{options[:vpc]}")
 
       network_acl = new_resource.driver.ec2.network_acls.create(options)
-      Retryable.retryable(:tries => 15, :sleep => 1, :on => AWS::EC2::Errors::InvalidNetworkAclID::NotFound) do
+      Retryable.retryable(:tries => 15, :sleep => lambda { |n| 2**n }, :on => AWS::EC2::Errors::InvalidNetworkAclID::NotFound) do
         network_acl.tags['Name'] = new_resource.name
       end
       network_acl

--- a/lib/chef/provider/aws_network_acl.rb
+++ b/lib/chef/provider/aws_network_acl.rb
@@ -20,7 +20,7 @@ class Chef::Provider::AwsNetworkAcl < Chef::Provisioning::AWSDriver::AWSProvider
       Chef::Log.debug("VPC: #{options[:vpc]}")
 
       network_acl = new_resource.driver.ec2.network_acls.create(options)
-      Retryable.retryable(:tries => 15, :sleep => lambda { |n| 2**n }, :on => AWS::EC2::Errors::InvalidNetworkAclID::NotFound) do
+      retry_with_backoff(AWS::EC2::Errors::InvalidNetworkAclID::NotFound) do
         network_acl.tags['Name'] = new_resource.name
       end
       network_acl

--- a/lib/chef/provider/aws_network_interface.rb
+++ b/lib/chef/provider/aws_network_interface.rb
@@ -35,10 +35,11 @@ class Chef::Provider::AwsNetworkInterface < Chef::Provisioning::AWSDriver::AWSPr
   def create_aws_object
     eni = nil
     converge_by "create new #{new_resource} in #{region}" do
-      eni = new_resource.driver.ec2.network_interfaces.create(options)
-      Retryable.retryable(:tries => 15, :sleep => lambda { |n| 2**n }, :on => AWS::EC2::Errors::InvalidNetworkInterfaceID::NotFound) do
+      eni = new_resource9.driver.ec2.network_interfaces.create(options)
+      retry_with_backoff(AWS::EC2::Errors::InvalidNetworkInterfaceID::NotFound) do
         eni.tags['Name'] = new_resource.name
       end
+      eni
     end
 
     converge_by "wait for new #{new_resource} in #{region} to become available" do

--- a/lib/chef/provider/aws_route_table.rb
+++ b/lib/chef/provider/aws_route_table.rb
@@ -23,7 +23,7 @@ class Chef::Provider::AwsRouteTable < Chef::Provisioning::AWSDriver::AWSProvider
 
     converge_by "create new route table #{new_resource.name} in VPC #{new_resource.vpc} (#{vpc.id}) and region #{region}" do
       route_table = new_resource.driver.ec2.route_tables.create(options)
-      Retryable.retryable(:tries => 15, :sleep => lambda { |n| 2**n }, :on => AWS::EC2::Errors::InvalidRouteTableID::NotFound) do
+      retry_with_backoff(AWS::EC2::Errors::InvalidRouteTableID::NotFound) do
         route_table.tags['Name'] = new_resource.name
       end
       route_table

--- a/lib/chef/provider/aws_route_table.rb
+++ b/lib/chef/provider/aws_route_table.rb
@@ -23,7 +23,7 @@ class Chef::Provider::AwsRouteTable < Chef::Provisioning::AWSDriver::AWSProvider
 
     converge_by "create new route table #{new_resource.name} in VPC #{new_resource.vpc} (#{vpc.id}) and region #{region}" do
       route_table = new_resource.driver.ec2.route_tables.create(options)
-      Retryable.retryable(:tries => 15, :sleep => 1, :on => AWS::EC2::Errors::InvalidRouteTableID::NotFound) do
+      Retryable.retryable(:tries => 15, :sleep => lambda { |n| 2**n }, :on => AWS::EC2::Errors::InvalidRouteTableID::NotFound) do
         route_table.tags['Name'] = new_resource.name
       end
       route_table

--- a/lib/chef/provider/aws_sqs_queue.rb
+++ b/lib/chef/provider/aws_sqs_queue.rb
@@ -4,12 +4,8 @@ class Chef::Provider::AwsSqsQueue < Chef::Provisioning::AWSDriver::AWSProvider
 
   def create_aws_object
     converge_by "create new SQS queue #{new_resource.name} in #{region}" do
-      # TODO need timeout here.
-      begin
+      retry_with_backoff(AWS::SQS::Errors::QueueDeletedRecently) do
         new_resource.driver.sqs.queues.create(new_resource.name, new_resource.options || {})
-      rescue AWS::SQS::Errors::QueueDeletedRecently
-        sleep 5
-        retry
       end
     end
   end

--- a/lib/chef/provider/aws_subnet.rb
+++ b/lib/chef/provider/aws_subnet.rb
@@ -32,8 +32,10 @@ class Chef::Provider::AwsSubnet < Chef::Provisioning::AWSDriver::AWSProvider
 
     converge_by "create new subnet #{new_resource.name} with CIDR #{cidr_block} in VPC #{new_resource.vpc} (#{options[:vpc]}) in #{region}" do
       subnet = new_resource.driver.ec2.subnets.create(cidr_block, options)
-      subnet.tags['Name'] = new_resource.name
-      subnet.tags['VPC'] = new_resource.vpc
+      retry_with_backoff(AWS::EC2::Errors::InvalidSubnetID::NotFound) do
+        subnet.tags['Name'] = new_resource.name
+        subnet.tags['VPC'] = new_resource.vpc
+      end
       subnet
     end
   end

--- a/lib/chef/provider/aws_vpc.rb
+++ b/lib/chef/provider/aws_vpc.rb
@@ -165,7 +165,7 @@ class Chef::Provider::AwsVpc < Chef::Provisioning::AWSDriver::AWSProvider
       if !current_ig
         converge_by "attach new Internet Gateway to VPC #{vpc.id}" do
           current_ig = AWS.ec2(config: vpc.config).internet_gateways.create
-          Retryable.retryable(:tries => 15, :sleep => 1, :matching => /never obtained existence/) do
+          Retryable.retryable(:tries => 15, :sleep => lambda { |n| 2**n }, :matching => /never obtained existence/) do
             raise "internet gateway for VPC #{vpc.id} never obtained existence" unless current_ig.exists?
           end
           action_handler.report_progress "create Internet Gateway #{current_ig.id}"

--- a/lib/chef/provisioning/aws_driver/aws_provider.rb
+++ b/lib/chef/provisioning/aws_driver/aws_provider.rb
@@ -313,5 +313,12 @@ class AWSProvider < Chef::Provider::LWRPBase
     end
   end
 
+  # Retry a block with an doubling backoff time (maximum wait of 10 seconds).
+  # @param retry_on [Exception] An exception to retry on, defaults to RuntimeError
+  #
+  def retry_with_backoff(retry_on = RuntimeError, &block)
+    Retryable.retryable(:tries => 10, :sleep => lambda { |n| [2**n, 10].min }, :on => retry_on, &block)
+  end
+
 end
 end

--- a/lib/chef/provisioning/aws_driver/aws_provider.rb
+++ b/lib/chef/provisioning/aws_driver/aws_provider.rb
@@ -276,7 +276,7 @@ class AWSProvider < Chef::Provider::LWRPBase
     expected_status = [expected_status].flatten
     current_status = aws_object.status
 
-    Retryable.retryable(:tries => tries, :sleep => sleep, :on => StatusTimeoutError) do |retries, exception|
+    Retryable.retryable(:tries => tries, :sleep => sleep) do |retries, exception|
       action_handler.report_progress "waited #{retries*sleep}/#{tries*sleep}s for #{aws_object.id} status to change to #{expected_status.inspect}..."
       begin
         current_status = aws_object.status
@@ -301,7 +301,7 @@ class AWSProvider < Chef::Provider::LWRPBase
     expected_states = [expected_states].flatten
     current_state = aws_object.state
 
-    Retryable.retryable(:tries => tries, :sleep => sleep, :on => StatusTimeoutError) do |retries, exception|
+    Retryable.retryable(:tries => tries, :sleep => sleep) do |retries, exception|
       action_handler.report_progress "waited #{retries*sleep}/#{tries*sleep}s for #{aws_object.id} state to change to #{expected_states.inspect}..."
       begin
         current_state = aws_object.state


### PR DESCRIPTION
Some of the tests were failing and this seems to help.  But it is also a good idea.

Do you think we should cap the timeout at 8 or 16 seconds and stop doubling it there?

\cc @fnichol @jkeiser @randomcamel 