### PR TITLE
only update bootstrap_options[:user_data] in windows, if one hasn't been provided

### DIFF
--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -626,7 +626,7 @@ EOD
 
       if machine_options[:is_windows]
         Chef::Log.debug "Setting WinRM userdata..."
-        bootstrap_options[:user_data] = user_data
+        bootstrap_options[:user_data] = user_data unless bootstrap_options.has_key?("user_data")
       else
         Chef::Log.debug "Non-windows, not setting userdata"
       end

--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -626,7 +626,7 @@ EOD
 
       if machine_options[:is_windows]
         Chef::Log.debug "Setting WinRM userdata..."
-        bootstrap_options[:user_data] = user_data unless bootstrap_options.has_key?("user_data")
+        bootstrap_options[:user_data] = user_data if bootstrap_options[:user_data].nil?
       else
         Chef::Log.debug "Non-windows, not setting userdata"
       end


### PR DESCRIPTION
bootstrap_options[:user_data] always gets overwritten even if the user has provided their own.