### PR TITLE
Fix handling of lb server certificates, fixes #258

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,43 @@ with_machine_options({
 This options hash can be supplied to either `with_machine_options` or directly into the `machine_options`
 attribute.
 
+# Load Balancer Options
+
+You can configure the ELB options by setting `with_load_balancer_options` or specifying them on each `load_balancer` resource.
+
+```ruby
+machine 'test1'
+m2 = machine 'test2'
+load_balancer "my_elb" do
+  machines ['test1', m2]
+  load_balancer_options({
+    subnets: subnets,
+    security_groups: [load_balancer_sg],
+    listeners: [
+      {
+          instance_port: 8080,
+          protocol: 'HTTP',
+          instance_protocol: 'HTTP',
+          port: 80
+      },
+      {
+          instance_port: 8080,
+          protocol: 'HTTPS',
+          instance_protocol: 'HTTP',
+          port: 443,
+          ssl_certificate_id: "arn:aws:iam::360965486607:server-certificate/cloudfront/foreflight-2015-07-09"
+      }
+    ]
+  })
+```
+
+The available parameters for `load_balancer_options` can be viewed at http://docs.aws.amazon.com/AWSRubySDK/latest/AWS/ELB/Client.html#create_load_balancer-instance_method .
+
+NOTES:
+
+1. You can specify either `ssl_certificate_id` or `server_certificate` in a listener but the value to both parameters should be the ARN of an existing IAM::ServerCertificate object.
+2. Instead of specifying `tags` in the `load_balancer_options`, you should specify `aws_tags`.  See the note on [tagging base resources](https://github.com/chef/chef-provisioning-aws#base-resources).
+
 # Specifying a Chef Server
 
 See [Pointing Boxes at Chef Servers](https://github.com/chef/chef-provisioning/blob/master/README.md#pointing-boxes-at-chef-servers)

--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -362,6 +362,9 @@ module AWSDriver
     end
 
     # Compare two server certificates by casting them both to strings.
+    #
+    # The parameters should either be a String containing the
+    # certificate ARN, or a IAM::ServerCertificate object.
     def server_certificate_eql?(cert1, cert2)
       server_cert_to_string(cert1) == server_cert_to_string(cert2)
     end

--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -254,7 +254,8 @@ module AWSDriver
                   listener.delete
                   actual_elb.listeners.create(desired_listener)
                 end
-              elsif listener.server_certificate != desired_listener[:server_certificate]
+              elsif ! server_certificate_eql?(listener.server_certificate,
+                                              server_cert_from_spec(desired_listener))
                 # Server certificate is mutable - if no immutable changes required a full recreate, update cert
                 perform_action.call("    update server certificate from #{listener.server_certificate} to #{desired_listener[:server_certificate]}") do
                   listener.server_certificate = desired_listener[:server_certificate]
@@ -357,6 +358,31 @@ module AWSDriver
       unless old_elb.nil?
         Chef::Log.warn("It is possible there are now 2 ELB instances - #{old_elb.name} and #{actual_elb.name}. " +
         "Determine which is correct and manually clean up the other.")
+      end
+    end
+
+    # Compare two server certificates by casting them both to strings.
+    def server_certificate_eql?(cert1, cert2)
+      server_cert_to_string(cert1) == server_cert_to_string(cert2)
+    end
+
+    def server_cert_to_string(cert)
+      if cert.respond_to?(:arn)
+        cert.arn
+      else
+        cert
+      end
+    end
+
+    # Retreive the server certificate from a listener spec, prefering
+    # the server_certificate key.
+    def server_cert_from_spec(spec)
+      if spec[:server_certificate]
+        spec[:server_certificate]
+      elsif spec[:ssl_certificate_id]
+        spec[:ssl_certificate_id]
+      else
+        nil
       end
     end
 


### PR DESCRIPTION
Previously, if a user specified an ARN for the `server_certificate` key
in a listener spec, the LB creation would succeed, but future updates
would always update the server_certificate.  If the user specified an
ARN for the `ssl_certificate_id`, the creation would succeed, but future
updates would fail.  Here we support both.