### PR TITLE
Adding retry logic around tagging for resources which don't have a Name tag

### DIFF
--- a/lib/chef/provisioning/aws_driver/aws_provider.rb
+++ b/lib/chef/provisioning/aws_driver/aws_provider.rb
@@ -121,7 +121,11 @@ class AWSProvider < Chef::Provider::LWRPBase
       aws_object = create_aws_object
     end
 
-    converge_tags(aws_object)
+    # If the resource hasn't obtained full existence yet this will failed
+    # It could have different errors from different resources
+    retry_with_backoff do
+      converge_tags(aws_object)
+    end
 
     #
     # Associate the managed entry with the AWS object


### PR DESCRIPTION
Found another place we weren't retrying when tagging failed with `NotFound`

\cc @jkeiser @randomcamel 