### PR TITLE
Eliminate deprecation warnings about 'dsl_name'.

### DIFF
--- a/lib/chef/provisioning/aws_driver/aws_resource.rb
+++ b/lib/chef/provisioning/aws_driver/aws_resource.rb
@@ -133,7 +133,6 @@ class AWSResource < Chef::Provisioning::AWSDriver::SuperLWRP
                         load_provider: true,
                         id: :name,
                         aws_id_prefix: nil)
-    self.resource_name = self.dsl_name
     @aws_sdk_class = sdk_class
     @aws_sdk_class_id = id
     @aws_id_prefix = aws_id_prefix


### PR DESCRIPTION
Fixes #288.