### PR TITLE
Add from_image support

### DIFF
--- a/chef-provisioning-aws.gemspec
+++ b/chef-provisioning-aws.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/opscode/chef-provisioning-aws'
 
   s.add_dependency 'chef', '>= 11.16.4'
-  s.add_dependency 'chef-provisioning', '~> 1.0'
+  s.add_dependency 'chef-provisioning', '~> 1.3'
   s.add_dependency 'aws-sdk-v1', '>= 1.59.0'
   s.add_dependency 'retryable', '~> 2.0.1'
   s.add_dependency 'ubuntu_ami', '~> 0.4.1'

--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -660,7 +660,7 @@ EOD
     def bootstrap_options_for(action_handler, machine_spec, machine_options)
       bootstrap_options = (machine_options[:bootstrap_options] || {}).to_h.dup
       bootstrap_options[:instance_type] ||= default_instance_type
-      image_id = bootstrap_options[:image_id] || machine_options[:image_id] || default_ami_for_region(aws_config.region)
+      image_id = machine_options[:from_image] || bootstrap_options[:image_id] || machine_options[:image_id] || default_ami_for_region(aws_config.region)
       bootstrap_options[:image_id] = image_id
       if !bootstrap_options[:key_name]
         Chef::Log.debug('No key specified, generating a default one...')

--- a/spec/integration/machine_spec.rb
+++ b/spec/integration/machine_spec.rb
@@ -52,6 +52,20 @@ describe Chef::Resource::Machine do
           source_dest_check: false
         ).and be_idempotent
       end
+
+      it "machine with from_image option is created from correct image", :super_slow do
+        expect_recipe {
+
+          machine_image 'test_machine_ami'
+
+          machine 'test_machine' do
+            from_image 'test_machine_ami'
+            action :allocate
+          end
+        }.to create_an_aws_instance('test_machine',
+          image_id: test_machine_ami.aws_object.id
+        ).and be_idempotent
+      end
     end
 
     with_aws "Without a VPC" do

--- a/spec/integration/machine_spec.rb
+++ b/spec/integration/machine_spec.rb
@@ -72,7 +72,7 @@ describe Chef::Resource::Machine do
             action :allocate
           end
         }.to create_an_aws_instance('test_machine',
-          image_id: test_machine_ami.aws_object.id
+          image_id: driver.ec2.images.filter('name', 'test_machine_ami').first.image_id
         ).and be_idempotent
       end
     end

--- a/spec/integration/machine_spec.rb
+++ b/spec/integration/machine_spec.rb
@@ -73,8 +73,11 @@ describe Chef::Resource::Machine do
           end
         }.to create_an_aws_instance('test_machine',
           image_id: driver.ec2.images.filter('name', 'test_machine_ami').first.image_id
+        ).and create_an_aws_image('test_machine_ami',
+          name: 'test_machine_ami'
         ).and be_idempotent
       end
+
     end
 
     with_aws "Without a VPC" do

--- a/spec/integration/machine_spec.rb
+++ b/spec/integration/machine_spec.rb
@@ -56,10 +56,19 @@ describe Chef::Resource::Machine do
       it "machine with from_image option is created from correct image", :super_slow do
         expect_recipe {
 
-          machine_image 'test_machine_ami'
+          machine_image 'test_machine_ami' do
+            machine_options bootstrap_options: {
+              subnet_id: 'test_public_subnet',
+              key_name: 'test_key_pair'
+            }
+          end
 
           machine 'test_machine' do
             from_image 'test_machine_ami'
+            machine_options bootstrap_options: {
+              subnet_id: 'test_public_subnet',
+              key_name: 'test_key_pair'
+            }
             action :allocate
           end
         }.to create_an_aws_instance('test_machine',


### PR DESCRIPTION
Previously `from_image` implementation was missing. After this fix https://github.com/chef/chef-provisioning/pull/366 this implementation is possible now.

Fixes https://github.com/chef/chef-provisioning-aws/issues/193

@tyler-ball please take a look. Spec is green, I've also tested manually :) Would love to see it merged and 1.4 released soon.