### PR TITLE
Adding api V2 for machine create and destroy, fixes #216

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ configure the machine.  These are all the available options:
 
 ```ruby
 with_machine_options({
+  # See https://github.com/chef/chef-provisioning#machine-options for options shared between drivers
   bootstrap_options: {
     # http://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Resource.html#create_instances-instance_method
     # lists the available options.  The below options are the default
@@ -117,46 +118,8 @@ with_machine_options({
     key_path: "~/.chef/keys/chef_default", # only necessary if storing keys some other location
     user_data: "...", # Only defaulted on Windows instances to start winrm
   },
-  convergence_options: {
-    chef_version: "12.4.1",
-    prerelease: "false",
-    chef_client_timeout: 120*60, # Default: 2 hours
-    chef_config: "log_level :debug\\n", # String containing additional text to inject into client.rb
-    chef_server: "http://my.chef.server/", # TODO could conflict with https://github.com/chef/chef-provisioning#pointing-boxes-at-chef-servers
-    bootstrap_proxy: "http://localhost:1234",
-    ssl_verify_mode: :verify_peer,
-    client_rb_path: "/etc/chef/client.rb", # <- DEFAULT, overwrite if necessary
-    client_pem_path: "/etc/chef/client.pem", # <- DEFAULT, overwrite if necessary
-    allow_overwrite_keys: false, # If there is an existing client.pem this needs to be true to overwrite it
-    private_key_options: {}, # TODO ????? Something to do with creating node object
-    source_key: "", # ?????
-    source_key_pass_phrase: "", # ?????
-    source_key_path: "", # ?????
-    public_key_path: "", # ?????
-    public_key_format: "", # ?????
-    admin: "", # ?????
-    validator: "", # ?????
-    ohai_hints: { :ec2 => { :key => :value } }, # Map from hint file name to file contents, this would create /etc/chef/ohai/hints/ec2.json
-    # The following are only available for Linux machines
-    install_sh_url: "https://www.chef.io/chef/install.sh", # <- DEFAULT, overwrite if necessary
-    install_sh_path: "/tmp/chef-install.sh", # <- DEFAULT, overwrite if necessary
-    install_sh_arguments: "-P chef-dk", # Additional commands to pass to install.sh
-    # The following are only available for Windows machines
-    install_msi_url: "foo://bar.com"
-  },
-  ssh_options: {
-    ...
-  },
-  cached_installer: false, # ???
-  aws_tags: { :key1 => "value", "key2" => "value"},
-  source_dest_check: false, # Specifies whether to enable an instance launched in a VPC to perform NAT
-  is_windows: false, # set to true if using a Windows AMI
-  ssh_username: "ubuntu",
-  ssh_gateway: "localhost"
-  sudo: true,
   use_private_ip_for_ssh: false, # DEPRECATED, use `transport_address_location`
   transport_address_location: :public_ip, # `:public_ip` (default), `:private_ip` or `:dns`.  Defines how SSH or WinRM should find an address to communicate with the instance.
-  ...
 })
 ```
 

--- a/chef-provisioning-aws.gemspec
+++ b/chef-provisioning-aws.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'chef', '>= 11.16.4'
   s.add_dependency 'chef-provisioning', '~> 1.3'
   s.add_dependency 'aws-sdk-v1', '>= 1.59.0'
+  s.add_dependency 'aws-sdk', '~> 2.1'
   s.add_dependency 'retryable', '~> 2.0.1'
   s.add_dependency 'ubuntu_ami', '~> 0.4.1'
 

--- a/lib/chef/provisioning/aws_driver/aws_resource.rb
+++ b/lib/chef/provisioning/aws_driver/aws_resource.rb
@@ -133,13 +133,14 @@ class AWSResource < Chef::Provisioning::AWSDriver::SuperLWRP
                         load_provider: true,
                         id: :name,
                         aws_id_prefix: nil)
+    # TODO less than Chef 12.4, this is necessary.  Above that, this is deprecated.
     self.resource_name = self.dsl_name
     @aws_sdk_class = sdk_class
     @aws_sdk_class_id = id
     @aws_id_prefix = aws_id_prefix
 
     # Go ahead and require the provider since we're here anyway ...
-    require "chef/provider/#{resource_name}" if load_provider
+    require "chef/provider/#{resource_name.to_s}" if load_provider
 
     option_name = :"#{resource_name[4..-1]}" if option_name == NOT_PASSED
     @aws_sdk_option_name = option_name

--- a/lib/chef/provisioning/aws_driver/aws_resource.rb
+++ b/lib/chef/provisioning/aws_driver/aws_resource.rb
@@ -133,14 +133,13 @@ class AWSResource < Chef::Provisioning::AWSDriver::SuperLWRP
                         load_provider: true,
                         id: :name,
                         aws_id_prefix: nil)
-    # TODO less than Chef 12.4, this is necessary.  Above that, this is deprecated.
-    self.resource_name = self.dsl_name
+    self.resource_name = convert_to_snake_case(self.name.split('::')[-1])
     @aws_sdk_class = sdk_class
     @aws_sdk_class_id = id
     @aws_id_prefix = aws_id_prefix
 
     # Go ahead and require the provider since we're here anyway ...
-    require "chef/provider/#{resource_name.to_s}" if load_provider
+    require "chef/provider/#{resource_name}" if load_provider
 
     option_name = :"#{resource_name[4..-1]}" if option_name == NOT_PASSED
     @aws_sdk_option_name = option_name

--- a/lib/chef/provisioning/aws_driver/credentials2.rb
+++ b/lib/chef/provisioning/aws_driver/credentials2.rb
@@ -1,0 +1,51 @@
+require "aws-sdk"
+require "aws-sdk-core/credentials"
+require "aws-sdk-core/shared_credentials"
+require "aws-sdk-core/instance_profile_credentials"
+require "aws-sdk-core/assume_role_credentials"
+
+class Chef
+module Provisioning
+module AWSDriver
+
+  class LoadCredentialsError < RuntimeError; end
+
+  # Loads the credentials for the AWS SDK V2
+  # Attempts to load credentials in the order specified at http://docs.aws.amazon.com/sdkforruby/api/index.html#Configuration
+  class Credentials2
+
+    attr_reader :profile_name
+
+    # @param [Hash] options
+    # @option options [String] :profile_name (ENV["AWS_DEFAULT_PROFILE"]) The profile name to use
+    #    when loading the config from '~/.aws/credentials'.  This can be nil.
+    def initialize(options = {})
+      @profile_name = options.fetch(:profile_name, nil) || ENV["AWS_DEFAULT_PROFILE"]
+    end
+
+    # Try to load the credentials from an ordered list of sources and return the first one that
+    # can be loaded successfully.
+    def get_credentials
+      shared_creds = ::Aws::SharedCredentials.new(:profile_name => profile_name)
+      instance_profile_creds = ::Aws::InstanceProfileCredentials.new(:retries => 1)
+
+      if ENV["AWS_ACCESS_KEY_ID"] && ENV["AWS_SECRET_ACCESS_KEY"]
+        creds = ::Aws::Credentials.new(
+          ENV["AWS_ACCESS_KEY_ID"],
+          ENV["AWS_SECRET_ACCESS_KEY"],
+          ENV["AWS_SESSION_TOKEN"]
+        )
+      elsif shared_creds.set?
+        creds = shared_creds
+      elsif instance_profile_creds.set?
+        creds = instance_profile_creds
+      else
+        raise LoadCredentialsError.new("Could not load credentials from the environment variables, the .aws/credentials file or the metadata service")
+      end
+      creds
+    end
+  end
+
+end
+end
+end

--- a/lib/chef/provisioning/aws_driver/credentials2.rb
+++ b/lib/chef/provisioning/aws_driver/credentials2.rb
@@ -20,7 +20,7 @@ module AWSDriver
     # @option options [String] :profile_name (ENV["AWS_DEFAULT_PROFILE"]) The profile name to use
     #    when loading the config from '~/.aws/credentials'.  This can be nil.
     def initialize(options = {})
-      @profile_name = options.fetch(:profile_name, nil) || ENV["AWS_DEFAULT_PROFILE"]
+      @profile_name = options[:profile_name] || ENV["AWS_DEFAULT_PROFILE"]
     end
 
     # Try to load the credentials from an ordered list of sources and return the first one that

--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -18,9 +18,11 @@ require 'chef/resource/aws_load_balancer'
 require 'chef/provisioning/aws_driver/aws_resource'
 require 'chef/provisioning/aws_driver/version'
 require 'chef/provisioning/aws_driver/credentials'
+require 'chef/provisioning/aws_driver/credentials2'
 
 require 'yaml'
 require 'aws-sdk-v1'
+require 'aws-sdk'
 require 'retryable'
 require 'ubuntu_ami'
 
@@ -60,6 +62,18 @@ module AWSDriver
         region: region || credentials[:region],
         proxy_uri: credentials[:proxy_uri] || nil,
         session_token: credentials[:aws_session_token] || nil,
+        logger: Chef::Log.logger
+      )
+
+      # TODO document how users could add something to the Aws.config themselves if they want to
+      # Right now we are supporting both V1 and V2, so we create 2 config sets
+      credentials2 = Credentials2.new(:profile_name => profile_name)
+      ::Aws.config.update(
+        credentials: credentials2.get_credentials,
+        region: region || ENV["AWS_DEFAULT_REGION"] || credentials[:region],
+        # TODO when we get rid of V1 replace the credentials class with something that knows how
+        # to read ~/.aws/config
+        :http_proxy => credentials[:proxy_uri] || nil,
         logger: Chef::Log.logger
       )
     end
@@ -477,46 +491,20 @@ EOD
 
     # Machine methods
     def allocate_machine(action_handler, machine_spec, machine_options)
-      actual_instance = instance_for(machine_spec)
+      instance = instance_for(machine_spec)
       bootstrap_options = bootstrap_options_for(action_handler, machine_spec, machine_options)
 
-      if actual_instance == nil || !actual_instance.exists? || actual_instance.status == :terminated
-
+      if instance == nil || !instance.exists? || instance.state.name == "terminated"
         action_handler.perform_action "Create #{machine_spec.name} with AMI #{bootstrap_options[:image_id]} in #{aws_config.region}" do
           Chef::Log.debug "Creating instance with bootstrap options #{bootstrap_options}"
 
-          actual_instance = ec2.instances.create(bootstrap_options.to_hash)
-          # Make sure the instance is ready to be tagged
-          wait_until_taggable(actual_instance)
-
-          # TODO add other tags identifying user / node url (same as fog)
-          actual_instance.tags['Name'] = machine_spec.name
-          actual_instance.source_dest_check = machine_options[:source_dest_check] if machine_options.has_key?(:source_dest_check)
-          machine_spec.reference = {
-              'driver_version' => Chef::Provisioning::AWSDriver::VERSION,
-              'allocated_at' => Time.now.utc.to_s,
-              'host_node' => action_handler.host_node,
-              'image_id' => bootstrap_options[:image_id],
-              'instance_id' => actual_instance.id
-          }
-          machine_spec.driver_url = driver_url
-          machine_spec.reference['key_name'] = bootstrap_options[:key_name] if bootstrap_options[:key_name]
-          # TODO 2.0 We no longer support `use_private_ip_for_ssh`, only `transport_address_location`
-          if machine_options[:use_private_ip_for_ssh]
-            unless @transport_address_location_warned
-              Chef::Log.warn("The machine_option ':use_private_ip_for_ssh' has been deprecated, use ':transport_address_location'")
-              @transport_address_location_warned = true
-            end
-            machine_options = Cheffish::MergedConfig.new(machine_options, {:transport_address_location => :private_ip})
-          end
-          %w(is_windows ssh_username sudo transport_address_location ssh_gateway).each do |key|
-            machine_spec.reference[key] = machine_options[key.to_sym] if machine_options[key.to_sym]
-          end
+          instance = create_instance_and_reference(bootstrap_options, action_handler, machine_spec, machine_options)
+          # TODO because we don't want to add `provider_tags` as a base attribute,
+          # we have to update the tags here in driver.rb instead of the providers
+          converge_tags(instance, machine_options[:aws_tags], action_handler)
         end
       end
-      # TODO because we don't want to add `provider_tags` as a base attribute,
-      # we have to update the tags here in driver.rb instead of the providers
-      converge_tags(actual_instance, machine_options[:aws_tags], action_handler)
+
     end
 
     def allocate_machines(action_handler, specs_and_options, parallelizer)
@@ -528,14 +516,15 @@ EOD
 
     def ready_machine(action_handler, machine_spec, machine_options)
       instance = instance_for(machine_spec)
+      converge_tags(instance, machine_options[:aws_tags], action_handler)
 
       if instance.nil?
         raise "Machine #{machine_spec.name} does not have an instance associated with it, or instance does not exist."
       end
 
-      if instance.status != :running
-        wait_until_machine(action_handler, machine_spec, instance) { instance.status != :stopping }
-        if instance.status == :stopped
+      if instance.state.name != "running"
+        wait_until_machine(action_handler, machine_spec, "finish stopping", instance) { instance.state.name != "stopping" }
+        if instance.state.name == "stopped"
           action_handler.perform_action "Start #{machine_spec.name} (#{machine_spec.reference['instance_id']}) in #{aws_config.region} ..." do
             instance.start
           end
@@ -579,6 +568,16 @@ EOD
 
     def ec2
       @ec2 ||= AWS::EC2.new(config: aws_config)
+    end
+
+    # The client for the SDK V2
+    def ec2_client
+      @ec2_client ||= ::Aws::EC2::Client.new
+    end
+
+    # The client for the SDK V2
+    def ec2_resource
+      @ec2_resource ||= ::Aws::EC2::Resource.new(ec2_client)
     end
 
     def elb
@@ -667,6 +666,8 @@ EOD
 
     def bootstrap_options_for(action_handler, machine_spec, machine_options)
       bootstrap_options = (machine_options[:bootstrap_options] || {}).to_h.dup
+      # These are hardcoded for now - only 1 machine at a time
+      bootstrap_options[:min_count] = bootstrap_options[:max_count] = 1
       bootstrap_options[:instance_type] ||= default_instance_type
       image_id = machine_options[:from_image] || bootstrap_options[:image_id] || machine_options[:image_id] || default_ami_for_region(aws_config.region)
       bootstrap_options[:image_id] = image_id
@@ -955,28 +956,31 @@ EOD
     end
 
     def wait_until_ready_machine(action_handler, machine_spec, instance=nil)
-      wait_until_machine(action_handler, machine_spec, instance) { instance.status == :running }
+      wait_until_machine(action_handler, machine_spec, "be ready", instance) { |instance|
+        instance.state.name == "running"
+      }
     end
 
-    def wait_until_machine(action_handler, machine_spec, instance=nil, &block)
+    def wait_until_machine(action_handler, machine_spec, output_msg, instance=nil, &block)
       instance ||= instance_for(machine_spec)
-      time_elapsed = 0
-      sleep_time = 10
-      max_wait_time = 120
-      if !yield(instance)
-        if action_handler.should_perform_actions
-          action_handler.report_progress "waiting for #{machine_spec.name} (#{instance.id} on #{driver_url}) to be ready ..."
-          while time_elapsed < max_wait_time && !yield(instance)
-            action_handler.report_progress "been waiting #{time_elapsed}/#{max_wait_time} -- sleeping #{sleep_time} seconds for #{machine_spec.name} (#{instance.id} on #{driver_url}) to be ready ..."
-            sleep(sleep_time)
-            time_elapsed += sleep_time
+      # TODO make these configurable from Chef::Config
+      max_attempts = 12
+      delay = 10
+      log_progress = Proc.new do |attempts, response|
+        action_handler.report_progress "been waiting #{delay*attempts}/#{delay*max_attempts} -- sleeping #{delay} seconds for #{machine_spec.name} (#{instance.id} on #{driver_url}) to #{output_msg} ..."
+      end
+      if action_handler.should_perform_actions
+        no_wait = yield(instance)
+        unless no_wait
+          action_handler.report_progress "waiting for #{machine_spec.name} (#{instance.id} on #{driver_url}) to #{output_msg} ..."
+          instance.wait_until(:max_attempts => max_attempts, :delay => delay, before_wait: log_progress) do |instance|
+            yield(instance)
           end
-          unless yield(instance)
-            raise "Image #{instance.id} did not become ready within #{max_wait_time} seconds"
-          end
-          action_handler.report_progress "#{machine_spec.name} is now ready"
         end
       end
+      # We need an instance.reload here because the `wait_until` does not reload the instance it is called on,
+      # only the instance that is passed to the block
+      instance.reload
     end
 
     def wait_for_transport(action_handler, machine_spec, machine_options)
@@ -1027,18 +1031,20 @@ EOD
       default_key_name
     end
 
-    def create_servers(action_handler, specs_and_options, parallelizer, &block)
+    def create_servers(action_handler, specs_and_options, parallelizer)
       specs_and_servers = instances_for(specs_and_options.keys)
 
       by_bootstrap_options = {}
       specs_and_options.each do |machine_spec, machine_options|
-        actual_instance = specs_and_servers[machine_spec]
-        if actual_instance
-          if actual_instance.status == :terminated
-            Chef::Log.warn "Machine #{machine_spec.name} (#{actual_instance.id}) is terminated.  Recreating ..."
+        instance = specs_and_servers[machine_spec]
+        if instance
+          if instance.state.name == "terminated"
+            Chef::Log.warn "Machine #{machine_spec.name} (#{instance.id}) is terminated.  Recreating ..."
           else
-            converge_tags(actual_instance, machine_options[:aws_tags], action_handler)
-            yield machine_spec, actual_instance if block_given?
+            # Even though the instance has been created the tags could be incorrect if it
+            # was created before tags were introduced
+            converge_tags(instance, machine_options[:aws_tags], action_handler)
+            yield machine_spec, instance if block_given?
             next
           end
         elsif machine_spec.reference
@@ -1062,34 +1068,16 @@ EOD
         action_handler.report_progress description
         if action_handler.should_perform_actions
           # Actually create the servers
-          create_many_instances(machine_specs.size, bootstrap_options, parallelizer) do |instance|
+          parallelizer.parallelize(1.upto(machine_specs.size)) do |i|
 
             # Assign each one to a machine spec
             machine_spec = machine_specs.pop
             machine_options = specs_and_options[machine_spec]
-            machine_spec.reference = {
-              'driver_version' => Chef::Provisioning::AWSDriver::VERSION,
-              'allocated_at' => Time.now.utc.to_s,
-              'host_node' => action_handler.host_node,
-              'image_id' => bootstrap_options[:image_id],
-              'instance_id' => instance.id
-            }
-            machine_spec.driver_url = driver_url
-            instance.tags['Name'] = machine_spec.name
-            instance.source_dest_check = machine_options[:source_dest_check] if machine_options.has_key?(:source_dest_check)
+
+            clean_bootstrap_options = Marshal.load(Marshal.dump(bootstrap_options))
+            instance = create_instance_and_reference(clean_bootstrap_options, action_handler, machine_spec, machine_options)
             converge_tags(instance, machine_options[:aws_tags], action_handler)
-            machine_spec.reference['key_name'] = bootstrap_options[:key_name] if bootstrap_options[:key_name]
-            # TODO 2.0 We no longer support `use_private_ip_for_ssh`, only `transport_address_location`
-            if machine_options[:use_private_ip_for_ssh]
-              unless @transport_address_location_warned
-                Chef::Log.warn("The machine_option ':use_private_ip_for_ssh' has been deprecated, use ':transport_address_location'")
-                @transport_address_location_warned = true
-              end
-              machine_options = Cheffish::MergedConfig.new(machine_options, {:transport_address_location => :private_ip})
-            end
-            %w(is_windows ssh_username sudo transport_address_location ssh_gateway).each do |key|
-              machine_spec.reference[key] = machine_options[key.to_sym] if machine_options[key.to_sym]
-            end
+
             action_handler.performed_action "machine #{machine_spec.name} created as #{instance.id} on #{driver_url}"
 
             yield machine_spec, instance if block_given?
@@ -1099,17 +1087,6 @@ EOD
             raise "Not all machines were created by create_servers"
           end
         end
-      end.to_a
-    end
-
-    def create_many_instances(num_servers, bootstrap_options, parallelizer)
-      parallelizer.parallelize(1.upto(num_servers)) do |i|
-        clean_bootstrap_options = Marshal.load(Marshal.dump(bootstrap_options))
-        instance = ec2.instances.create(clean_bootstrap_options.to_hash)
-        wait_until_taggable(instance)
-
-        yield instance if block_given?
-        instance
       end.to_a
     end
 
@@ -1150,10 +1127,37 @@ EOD
       end
     end
 
-    def wait_until_taggable(instance)
-      Retryable.retryable(:tries => 12, :sleep => 5, :on => [AWS::EC2::Errors::InvalidInstanceID::NotFound, TimeoutError]) do
-        raise TimeoutError unless instance.status == :pending || instance.status == :running
+    def create_instance_and_reference(bootstrap_options, action_handler, machine_spec, machine_options)
+      instance = ec2_resource.create_instances(bootstrap_options.to_hash)[0]
+      # Make sure the instance is ready to be tagged
+      instance.wait_until_exists
+
+      # Sometimes tagging fails even though the instance 'exists'
+      Retryable.retryable(:tries => 12, :sleep => 5, :on => [AWS::EC2::Errors::InvalidInstanceID::NotFound]) do
+        instance.create_tags({tags: [{key: "Name", value: machine_spec.name}]})
       end
+      instance.source_dest_check = machine_options[:source_dest_check] if machine_options.has_key?(:source_dest_check)
+      machine_spec.reference = {
+          'driver_version' => Chef::Provisioning::AWSDriver::VERSION,
+          'allocated_at' => Time.now.utc.to_s,
+          'host_node' => action_handler.host_node,
+          'image_id' => bootstrap_options[:image_id],
+          'instance_id' => instance.id
+      }
+      machine_spec.driver_url = driver_url
+      machine_spec.reference['key_name'] = bootstrap_options[:key_name] if bootstrap_options[:key_name]
+      # TODO 2.0 We no longer support `use_private_ip_for_ssh`, only `transport_address_location`
+      if machine_options[:use_private_ip_for_ssh]
+        unless @transport_address_location_warned
+          Chef::Log.warn("The machine_option ':use_private_ip_for_ssh' has been deprecated, use ':transport_address_location'")
+          @transport_address_location_warned = true
+        end
+        machine_options = Cheffish::MergedConfig.new(machine_options, {:transport_address_location => :private_ip})
+      end
+      %w(is_windows ssh_username sudo use_private_ip_for_ssh ssh_gateway).each do |key|
+        machine_spec.reference[key] = machine_options[key.to_sym] if machine_options[key.to_sym]
+      end
+      instance
     end
 
     def get_listeners(listeners)

--- a/lib/chef/resource/aws_instance.rb
+++ b/lib/chef/resource/aws_instance.rb
@@ -13,7 +13,7 @@ class Chef::Resource::AwsInstance < Chef::Provisioning::AWSDriver::AWSResourceWi
 
   def aws_object
     driver, id = get_driver_and_id
-    result = driver.ec2.instances[id] if id
+    result = driver.ec2_resource.instance(id) if id
     result && result.exists? ? result : nil
   end
 end

--- a/lib/chef/resource/aws_instance.rb
+++ b/lib/chef/resource/aws_instance.rb
@@ -1,9 +1,14 @@
 require 'chef/provisioning/aws_driver/aws_resource_with_entry'
 
 class Chef::Resource::AwsInstance < Chef::Provisioning::AWSDriver::AWSResourceWithEntry
-  aws_sdk_type AWS::EC2::Instance,
+  # The require needs to be inside this class otherwise it gets loaded before the rest of the SDK
+  # and starts causing issues - AWS expects to load all this stuff itself
+  aws_sdk_type ::Aws::EC2::Instance,
     managed_entry_type: :machine,
     managed_entry_id_name: 'instance_id'
+
+  # TODO need to remove this for now because the SDK V2 uses a different tagging mechanism
+  undef_method(:aws_tags)
 
   attribute :name, kind_of: String, name_attribute: true
 

--- a/spec/aws_support.rb
+++ b/spec/aws_support.rb
@@ -23,7 +23,7 @@ module AWSSupport
   require 'aws'
   require 'aws_support/deep_matcher/matchable_object'
   require 'aws_support/deep_matcher/matchable_array'
-  DeepMatcher::MatchableObject.matchable_classes << proc { |o| o.class.name =~ /^AWS::(EC2|ELB|IAM|S3|RDS|CloudSearch)($|::)/ }
+  DeepMatcher::MatchableObject.matchable_classes << proc { |o| o.class.name =~ /^(AWS|Aws)::(EC2|ELB|IAM|S3|RDS|CloudSearch)($|::)/ }
   DeepMatcher::MatchableArray.matchable_classes  << AWS::Core::Data::List
 
   def purge_all

--- a/spec/aws_support/matchers/have_aws_object_tags.rb
+++ b/spec/aws_support/matchers/have_aws_object_tags.rb
@@ -55,7 +55,12 @@ module AWSSupport
           end
           tags
         else
-          @aws_object.tags.to_h
+          tags = @aws_object.tags
+          if tags.is_a? AWS::EC2::ResourceTagCollection
+            tags.to_h
+          else
+            Hash[tags.map {|o| [o.key, o.value]}]
+          end
         end
       end
     end

--- a/spec/integration/aws_tagged_items_spec.rb
+++ b/spec/integration/aws_tagged_items_spec.rb
@@ -84,24 +84,24 @@ describe "AWS Tagged Items" do
         ).and be_idempotent
       end
 
-      # it "aws_instance 'test_instance' created with custom tag", :super_slow do
-      #   expect_recipe {
-      #     machine 'test_instance' do
-      #       action :allocate
-      #     end
-      #   }.to create_an_aws_instance('test_instance')
-      #
-      #   expect_recipe {
-      #     aws_instance "test_instance" do
-      #       aws_tags :project => 'FUN'
-      #     end
-      #   }.to update_an_aws_instance('test_instance'
-      #   ).and have_aws_instance_tags('test_instance',
-      #                                 { 'Name' => 'test_instance',
-      #                                   'project' => 'FUN'
-      #                                 }
-      #   ).and be_idempotent
-      # end
+      it "aws_instance 'test_instance' created with custom tag", :super_slow, :pending do
+        expect_recipe {
+          machine 'test_instance' do
+            action :allocate
+          end
+        }.to create_an_aws_instance('test_instance')
+
+        expect_recipe {
+          aws_instance "test_instance" do
+            aws_tags :project => 'FUN'
+          end
+        }.to update_an_aws_instance('test_instance'
+        ).and have_aws_instance_tags('test_instance',
+                                      { 'Name' => 'test_instance',
+                                        'project' => 'FUN'
+                                      }
+        ).and be_idempotent
+      end
 
       it "machine 'test_machine' created using machine_options aws_tag", :super_slow do
         expect_recipe {

--- a/spec/integration/aws_tagged_items_spec.rb
+++ b/spec/integration/aws_tagged_items_spec.rb
@@ -84,24 +84,24 @@ describe "AWS Tagged Items" do
         ).and be_idempotent
       end
 
-      it "aws_instance 'test_instance' created with custom tag", :super_slow do
-        expect_recipe {
-          machine 'test_instance' do
-            action :allocate
-          end
-        }.to create_an_aws_instance('test_instance')
-
-        expect_recipe {
-          aws_instance "test_instance" do
-            aws_tags :project => 'FUN'
-          end
-        }.to update_an_aws_instance('test_instance'
-        ).and have_aws_instance_tags('test_instance',
-                                      { 'Name' => 'test_instance',
-                                        'project' => 'FUN'
-                                      }
-        ).and be_idempotent
-      end
+      # it "aws_instance 'test_instance' created with custom tag", :super_slow do
+      #   expect_recipe {
+      #     machine 'test_instance' do
+      #       action :allocate
+      #     end
+      #   }.to create_an_aws_instance('test_instance')
+      #
+      #   expect_recipe {
+      #     aws_instance "test_instance" do
+      #       aws_tags :project => 'FUN'
+      #     end
+      #   }.to update_an_aws_instance('test_instance'
+      #   ).and have_aws_instance_tags('test_instance',
+      #                                 { 'Name' => 'test_instance',
+      #                                   'project' => 'FUN'
+      #                                 }
+      #   ).and be_idempotent
+      # end
 
       it "machine 'test_machine' created using machine_options aws_tag", :super_slow do
         expect_recipe {

--- a/spec/unit/chef/provisioning/aws_driver/driver_spec.rb
+++ b/spec/unit/chef/provisioning/aws_driver/driver_spec.rb
@@ -1,4 +1,5 @@
 require 'chef/provisioning/aws_driver/driver'
+require 'chef/provisioning/aws_driver/credentials2'
 
 describe Chef::Provisioning::AWSDriver::Driver do
 
@@ -7,6 +8,7 @@ describe Chef::Provisioning::AWSDriver::Driver do
     aws_access_key_id: "id",
     aws_secret_access_key: "secret"
   })}
+  let(:credentials2) { double("credentials2", :get_credentials => {})}
 
   before do
     expect_any_instance_of(Chef::Provisioning::AWSDriver::Driver).to receive(:aws_credentials).and_return(aws_credentials)
@@ -17,6 +19,8 @@ describe Chef::Provisioning::AWSDriver::Driver do
         region:            "us-east-1"
       })
     end
+    expect(Chef::Provisioning::AWSDriver::Credentials2).to receive(:new).and_return(credentials2)
+    expect(::Aws).to receive(:config).and_return({})
   end
 
   describe "#determine_remote_host" do


### PR DESCRIPTION
First stab at adding in API V2 support.  It requires loading both libraries, loading different clients and setting up different credentials.  My idea is that we would keep `Credential2` around until we got rid of v2 and then we would just rename it credentials.  Thoughts?

\cc @jkeiser @fnichol @randomcamel 

Fixes #216