### PR TITLE
Strip key_path from the bootstrap options

### DIFF
--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -691,6 +691,7 @@ EOD
       bootstrap_options[:instance_type] ||= default_instance_type
       image_id = machine_options[:from_image] || bootstrap_options[:image_id] || machine_options[:image_id] || default_ami_for_region(aws_config.region)
       bootstrap_options[:image_id] = image_id
+      bootstrap_options.delete(:key_path)
       if !bootstrap_options[:key_name]
         Chef::Log.debug('No key specified, generating a default one...')
         bootstrap_options[:key_name] = default_aws_keypair(action_handler, machine_spec)

--- a/spec/integration/machine_spec.rb
+++ b/spec/integration/machine_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'openssl'
 
 describe Chef::Resource::Machine do
   extend AWSSupport
@@ -113,6 +114,48 @@ describe Chef::Resource::Machine do
           end
         }.converge }.to_not raise_error
       end
+
+      # https://github.com/chef/chef-provisioning-aws/pull/295
+      context "with a custom key" do
+        let(:private_key) {
+          k = OpenSSL::PKey::RSA.new(2048)
+          f = Pathname.new(private_key_path)
+          f.write(k.to_pem)
+          k
+        }
+        let(:public_key) {private_key.public_key}
+        let(:private_key_path) {
+          Pathname.new(ENV['HOME']).join(".ssh", key_pair_name).expand_path
+        }
+        let(:key_pair_name) { "test_key_pair_#{Random.rand(100)}" }
+
+        before do
+          driver.ec2_client.import_key_pair({
+            key_name: key_pair_name, # required
+            public_key_material: "#{public_key.ssh_type} #{[public_key.to_blob].pack('m0')}", # required
+          })
+        end
+
+        after do
+          driver.ec2_client.delete_key_pair({
+            key_name: key_pair_name, # required
+          })
+          Pathname.new(private_key_path).delete
+        end
+
+        it "strips key_path from the bootstrap options when creating the machine", :super_slow do
+          expect_recipe {
+            machine 'test_machine' do
+              machine_options bootstrap_options: {
+                key_name: key_pair_name,
+                key_path: private_key_path
+              }
+            end
+          }.to create_an_aws_instance('test_machine'
+          ).and be_idempotent
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
The AWS SDK does not like the 'key_path' bootstrap option.

```
 ArgumentError
      -------------
      unexpected option key_path

      Resource Declaration:
      ---------------------
      # In /var/chef/cache/cookbooks/marketplace_ami/libraries/marketplace_ami_provider.rb

       49:         ami = machine_image(new_resource.name)
       50:

      Compiled Resource:
      ------------------
      # Declared in /var/chef/cache/cookbooks/marketplace_ami/libraries/marketplace_ami_provider.rb:49:in `create_image'

      machine_image("test-2015-08-18") do
        action [:create]
        retries 0
        retry_delay 2
        default_guard_interpreter :default
        chef_server {:chef_server_url=>"http://127.0.0.1:8889", :options=>{:client_name=>"dracarys", :signing_key_filename=>"/etc/chef/client.pem"}}
        driver "aws::us-east-1"
        machine_options {:bootstrap_options=>{:instance_type=>"t2.medium", :availability_zone=>"us-east-1a", :associate_public_ip_address=>true, :image_id=>"ami-0372b468", :key_name=>"ryan", :key_path=>
"/Users/ryan/.ssh/id_rsa"}, :convergence_options=>{:chef_client_timeout=>7200, :chef_verion=>"12.3.0"}, :ssh_username=>"ec2-user"}
        declared_type :machine_image
        cookbook_name "test"
        attribute_modifiers [[["test", "hello_world"], "Yay! our test image works"]]
        run_list_modifiers [#<Chef::RunList::RunListItem:0x007f98135f76b8 @version=nil, @type=:recipe, @name="test::hello_world">, #<Chef::RunList::RunListItem:0x007f98135f6e48 @version=nil, @type=:reci
pe, @name="marketplace_ami::_security_controls">]
      end
```