### PR TITLE
Add recursive_delete attribute to a aws_s3_bucket

### DIFF
--- a/lib/chef/provider/aws_s3_bucket.rb
+++ b/lib/chef/provider/aws_s3_bucket.rb
@@ -43,7 +43,11 @@ class Chef::Provider::AwsS3Bucket < Chef::Provisioning::AWSDriver::AWSProvider
 
   def destroy_aws_object(bucket)
     converge_by "delete S3 bucket #{new_resource.name}" do
-      bucket.delete
+      if new_resource.recursive_delete
+        bucket.delete!
+      else
+        bucket.delete
+      end
     end
   end
 

--- a/lib/chef/resource/aws_s3_bucket.rb
+++ b/lib/chef/resource/aws_s3_bucket.rb
@@ -7,6 +7,7 @@ class Chef::Resource::AwsS3Bucket < Chef::Provisioning::AWSDriver::AWSResource
   attribute :options, :kind_of => Hash, :default => {}
   attribute :enable_website_hosting, :kind_of => [TrueClass, FalseClass], :default => false
   attribute :website_options, :kind_of => Hash, :default => {}
+  attribute :recursive_delete, :kind_of => [TrueClass, FalseClass], :default => false
 
   def aws_object
     result = driver.s3.buckets[name]

--- a/spec/integration/aws_s3_bucket_spec.rb
+++ b/spec/integration/aws_s3_bucket_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+require 'securerandom'
+
+def mk_bucket_name
+  bucket_postfix = SecureRandom.hex(8)
+  "chef_provisioning_test_bucket_#{bucket_postfix}"
+end
+
+describe Chef::Resource::AwsS3Bucket do
+  extend AWSSupport
+
+  when_the_chef_12_server "exists", organization: "foo", server_scope: :context do
+    with_aws "when connected to AWS" do
+      bucket_name = mk_bucket_name
+      it "aws_s3_bucket '#{bucket_name}' creates a bucket" do
+        expect_recipe {
+          aws_s3_bucket bucket_name
+        }.to create_an_aws_s3_bucket(bucket_name).and be_idempotent
+      end
+    end
+
+    with_aws "when a bucket with content exists" do
+      bucket_name = mk_bucket_name
+      with_converge {
+        aws_s3_bucket bucket_name
+
+        ruby_block "upload s3 object" do
+          block do
+            AWS::S3.new.buckets[bucket_name].objects["test-object"].write("test-content")
+          end
+        end
+      }
+
+      it "aws_s3_bucket '#{bucket_name}' with recursive_delete set to true, deletes the bucket" do
+        r = recipe {
+          aws_s3_bucket bucket_name do
+            recursive_delete true
+            action :delete
+          end
+        }
+        expect(r).to destroy_an_aws_s3_bucket(bucket_name)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Non-empty S3 buckets have to be explicitly deleted with the #delete!
method rather than #delete.