### PR TITLE
Add aws_internet_gateway provider, fixes #143

### DIFF
--- a/lib/chef/provider/aws_internet_gateway.rb
+++ b/lib/chef/provider/aws_internet_gateway.rb
@@ -1,0 +1,63 @@
+require 'chef/provisioning/aws_driver/aws_provider'
+require 'retryable'
+
+class Chef::Provider::AwsInternetGateway < Chef::Provisioning::AWSDriver::AWSProvider
+
+  protected
+
+  def create_aws_object
+    self.vpc = Chef::Resource::AwsVpc.get_aws_object(new_resource.vpc, resource: new_resource) if new_resource.vpc
+
+    converge_by "create internet gateway #{new_resource.name} in region #{region}" do
+      internet_gateway = new_resource.driver.ec2.internet_gateways.create
+      retry_with_backoff(AWS::EC2::Errors::InvalidInternetGatewayID::NotFound) do
+        internet_gateway.tags['Name'] = new_resource.name
+      end
+
+      if vpc
+        attach_vpc(vpc, internet_gateway)
+      end
+
+      internet_gateway
+    end
+  end
+
+  def update_aws_object(internet_gateway)
+    self.vpc = internet_gateway.vpc
+
+    if new_resource.vpc
+      desired_vpc = Chef::Resource::AwsVpc.get_aws_object(new_resource.vpc, resource: new_resource)
+      if vpc != desired_vpc
+        attach_vpc(desired_vpc, internet_gateway)
+      end
+    end
+  end
+
+  def destroy_aws_object(internet_gateway)
+    converge_by "delete internet gateway #{new_resource.name} in region #{region}" do
+      begin
+        detach_vpc(internet_gateway)
+        internet_gateway.delete
+      rescue AWS::EC2::Errors::InvalidInternetGatewayID::NotFound
+        raise "internet gateway #{internet_gateway.id} not found"
+      end
+    end
+  end
+
+  private
+
+  attr_accessor :vpc
+
+  def attach_vpc(vpc, internet_gateway)
+    action_handler.perform_action "attach vpc #{vpc.id} to #{internet_gateway.id}" do
+      internet_gateway.vpc = vpc
+    end
+  end
+
+  def detach_vpc(internet_gateway)
+    action_handler.perform_action "detach any currently attached vpc from internet gateway #{internet_gateway.id}" do
+      internet_gateway.detach(internet_gateway.vpc) if internet_gateway.vpc
+    end
+  end
+
+end

--- a/lib/chef/provider/aws_internet_gateway.rb
+++ b/lib/chef/provider/aws_internet_gateway.rb
@@ -6,13 +6,13 @@ class Chef::Provider::AwsInternetGateway < Chef::Provisioning::AWSDriver::AWSPro
 
   def action_detach
     internet_gateway = Chef::Resource::AwsInternetGateway.get_aws_object(new_resource.name, resource: new_resource)
-    detach_aws_object(internet_gateway)
+    detach_vpc(internet_gateway)
   end
 
   protected
 
   def create_aws_object
-    self.vpc = Chef::Resource::AwsVpc.get_aws_object(new_resource.vpc, resource: new_resource) if new_resource.vpc
+    desired_vpc = Chef::Resource::AwsVpc.get_aws_object(new_resource.vpc, resource: new_resource) if new_resource.vpc
 
     converge_by "create internet gateway #{new_resource.name} in region #{region}" do
       internet_gateway = new_resource.driver.ec2.internet_gateways.create
@@ -20,8 +20,8 @@ class Chef::Provider::AwsInternetGateway < Chef::Provisioning::AWSDriver::AWSPro
         internet_gateway.tags['Name'] = new_resource.name
       end
 
-      if vpc
-        attach_vpc(vpc, internet_gateway)
+      if desired_vpc
+        attach_vpc(desired_vpc, internet_gateway)
       end
 
       internet_gateway
@@ -29,11 +29,11 @@ class Chef::Provider::AwsInternetGateway < Chef::Provisioning::AWSDriver::AWSPro
   end
 
   def update_aws_object(internet_gateway)
-    self.vpc = internet_gateway.vpc
+    current_vpc = internet_gateway.vpc
 
     if new_resource.vpc
       desired_vpc = Chef::Resource::AwsVpc.get_aws_object(new_resource.vpc, resource: new_resource)
-      if vpc != desired_vpc
+      if current_vpc != desired_vpc
         attach_vpc(desired_vpc, internet_gateway)
       end
     end
@@ -41,22 +41,8 @@ class Chef::Provider::AwsInternetGateway < Chef::Provisioning::AWSDriver::AWSPro
 
   def destroy_aws_object(internet_gateway)
     converge_by "delete internet gateway #{new_resource.name} in region #{region}" do
-      begin
-        detach_aws_object(internet_gateway)
-        internet_gateway.delete
-      rescue AWS::EC2::Errors::InvalidInternetGatewayID::NotFound
-        raise "internet gateway #{internet_gateway.id} not found"
-      end
-    end
-  end
-
-  def detach_aws_object(internet_gateway)
-    converge_by "detach internet gateway #{new_resource.name} in region #{region}" do
-      begin
-        detach_vpc(internet_gateway)
-      rescue AWS::EC2::Errors::InvalidInternetGatewayID::NotFound
-        raise "internet gateway #{internet_gateway.id} not found"
-      end
+      detach_vpc(internet_gateway)
+      internet_gateway.delete
     end
   end
 
@@ -65,14 +51,16 @@ class Chef::Provider::AwsInternetGateway < Chef::Provisioning::AWSDriver::AWSPro
   attr_accessor :vpc
 
   def attach_vpc(vpc, internet_gateway)
-    action_handler.perform_action "attach vpc #{vpc.id} to #{internet_gateway.id}" do
+    converge_by "attach vpc #{vpc.id} to #{internet_gateway.id}" do
       internet_gateway.vpc = vpc
     end
   end
 
   def detach_vpc(internet_gateway)
-    action_handler.perform_action "detach any currently attached vpc from internet gateway #{internet_gateway.id}" do
-      internet_gateway.detach(internet_gateway.vpc) if internet_gateway.vpc
+    if internet_gateway.vpc
+      converge_by "detach vpc #{internet_gateway.vpc.id} from internet gateway #{internet_gateway.id}" do
+        internet_gateway.detach(internet_gateway.vpc)
+      end
     end
   end
 

--- a/lib/chef/provider/aws_vpc.rb
+++ b/lib/chef/provider/aws_vpc.rb
@@ -194,6 +194,9 @@ class Chef::Provider::AwsVpc < Chef::Provisioning::AWSDriver::AWSProvider
               action :detach
             end
           end
+          aws_internet_gateway new_ig do
+            vpc vpc.id
+          end
         end
       when true
         if !current_ig

--- a/lib/chef/resource/aws_internet_gateway.rb
+++ b/lib/chef/resource/aws_internet_gateway.rb
@@ -1,5 +1,3 @@
-require 'chef/provisioning/aws_driver/aws_resource_with_entry'
-
 #
 # An AWS internet gateway, allowing communication between instances inside a VPC and the internet.
 #
@@ -17,6 +15,11 @@ class Chef::Resource::AwsInternetGateway < Chef::Provisioning::AWSDriver::AWSRes
   aws_sdk_type AWS::EC2::InternetGateway
 
   require 'chef/resource/aws_vpc'
+
+  #
+  # Extend actions for the internet gateway
+  #
+  actions :create, :destroy, :detach, :purge, :nothing
 
   #
   # The name of this internet gateway.

--- a/lib/chef/resource/aws_internet_gateway.rb
+++ b/lib/chef/resource/aws_internet_gateway.rb
@@ -1,18 +1,45 @@
-require 'chef/provisioning/aws_driver/aws_resource'
+require 'chef/provisioning/aws_driver/aws_resource_with_entry'
 
-class Chef::Resource::AwsInternetGateway < Chef::Provisioning::AWSDriver::AWSResource
+#
+# An AWS internet gateway, allowing communication between instances inside a VPC and the internet.
+#
+# `name` is not guaranteed unique for an AWS account; therefore, Chef will
+# store the internet gateway ID associated with this name in your Chef server in the
+# data bag `data/aws_internet_gateway/<name>`.
+#
+# API documentation for the AWS Ruby SDK for VPCs (and the object returned from `aws_object` can be found here:
+#
+# - http://docs.aws.amazon.com/AWSRubySDK/latest/AWS/EC2/InternetGateway.html
+#
+class Chef::Resource::AwsInternetGateway < Chef::Provisioning::AWSDriver::AWSResourceWithEntry
   include Chef::Provisioning::AWSDriver::AWSTaggable
 
-  aws_sdk_type AWS::EC2::InternetGateway, load_provider: false, id: :id
+  aws_sdk_type AWS::EC2::InternetGateway
 
+  require 'chef/resource/aws_vpc'
+
+  #
+  # The name of this internet gateway.
+  #
   attribute :name, kind_of: String, name_attribute: true
+
+  #
+  # A vpc to attach to the internet gateway.
+  #
+  # May be one of:
+  # - The name of an `aws_vpc` Chef resource.
+  # - An actual `aws_vpc` resource.
+  # - An AWS `VPC` object.
+  #
+  attribute :vpc, kind_of: [ String, AwsVpc, AWS::EC2::VPC ]
 
   attribute :internet_gateway_id, kind_of: String, aws_id_attribute: true, lazy_default: proc {
     name =~ /^igw-[a-f0-9]{8}$/ ? name : nil
   }
 
   def aws_object
-    result = driver.ec2.internet_gateways[internet_gateway_id]
+    driver, id = get_driver_and_id
+    result = driver.ec2.internet_gateways[id] if id
     result && result.exists? ? result : nil
   end
 end

--- a/lib/chef/resource/aws_internet_gateway.rb
+++ b/lib/chef/resource/aws_internet_gateway.rb
@@ -19,7 +19,7 @@ class Chef::Resource::AwsInternetGateway < Chef::Provisioning::AWSDriver::AWSRes
   #
   # Extend actions for the internet gateway
   #
-  actions :create, :destroy, :detach, :purge, :nothing
+  actions :create, :destroy, :detach
 
   #
   # The name of this internet gateway.

--- a/spec/integration/aws_internet_gateway_spec.rb
+++ b/spec/integration/aws_internet_gateway_spec.rb
@@ -5,8 +5,13 @@ describe Chef::Resource::AwsInternetGateway do
 
   when_the_chef_12_server 'exists', organization: 'foo', server_scope: :context do
     with_aws 'with a VPC' do
-      aws_vpc 'test_vpc_igw' do
+
+      aws_vpc 'test_vpc_igw_a' do
         cidr_block '10.0.0.0/24'
+      end
+
+      aws_vpc 'test_vpc_igw_b' do
+        cidr_block '10.0.1.0/24'
       end
 
       context 'add an internet gateway' do
@@ -21,12 +26,26 @@ describe Chef::Resource::AwsInternetGateway do
         it "aws_internet_gateway 'test_internet_gateway' attach vpc" do
           expect_recipe {
             aws_internet_gateway 'test_internet_gateway' do
-              vpc test_vpc_igw.aws_object.id
+              vpc test_vpc_igw_a.aws_object.id
             end
           }.to create_an_aws_internet_gateway('test_internet_gateway',
-                                              vpc: test_vpc_igw.aws_object).and be_idempotent
+                                              vpc: test_vpc_igw_a.aws_object).and be_idempotent
+        end
+      end
 
-          expect(test_vpc_igw.aws_object.internet_gateway.id).not_to be_nil
+      context 'update the attached vpc of an internet gateway' do
+        it "aws_internet_gateway 'test_internet_gateway' update vpc" do
+          converge {
+            aws_internet_gateway 'test_internet_gateway' do
+              vpc test_vpc_igw_a.aws_object.id
+            end
+
+            aws_internet_gateway 'test_internet_gateway' do
+              vpc test_vpc_igw_b.aws_object.id
+            end
+          }
+
+          expect(test_vpc_igw_b.aws_object.internet_gateway).not_to be_nil
         end
       end
 
@@ -34,15 +53,33 @@ describe Chef::Resource::AwsInternetGateway do
         it "aws_internet_gateway 'test_internet_gateway' detach vpc" do
           converge {
             aws_internet_gateway 'test_internet_gateway' do
-              vpc test_vpc_igw.aws_object.id
+              vpc test_vpc_igw_a.aws_object.id
             end
 
+            aws_internet_gateway 'test_internet_gateway' do
+              action :detach
+            end
+          }
+
+          expect(test_vpc_igw_a.aws_object.internet_gateway).to be_nil
+        end
+      end
+    end
+
+    with_aws 'with an Internet Gateway' do
+      with_converge {
+        aws_internet_gateway 'test_internet_gateway'
+      }
+
+      context 'destroy an internet gateway' do
+        it "aws_internet_gateway 'test_internet_gateway'" do
+          r = recipe {
             aws_internet_gateway 'test_internet_gateway' do
               action :destroy
             end
           }
 
-          expect(test_vpc_igw.aws_object.internet_gateway).to be_nil
+          expect(r).to destroy_an_aws_internet_gateway('test_internet_gateway').and be_idempotent
         end
       end
     end

--- a/spec/integration/aws_internet_gateway_spec.rb
+++ b/spec/integration/aws_internet_gateway_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe Chef::Resource::AwsInternetGateway do
+  extend AWSSupport
+
+  when_the_chef_12_server "exists", organization: 'foo', server_scope: :context do
+    with_aws "with a VPC and an internet gateway" do
+      vpc = nil
+      internet_gateway = nil
+
+      before {
+        vpc = driver.ec2.vpcs.create('10.0.0.0/24')
+      }
+
+      it "aws_internet_gateway 'test_internet_gateway' with no parameters" do
+        expect_recipe {
+          aws_internet_gateway 'test_internet_gateway'
+        }.to create_an_aws_internet_gateway('test_internet_gateway').and be_idempotent
+      end
+
+      it "aws_internet_gateway 'test_internet_gateway' with attached vpc" do
+        expect_recipe {
+          aws_internet_gateway 'test_internet_gateway' do
+            vpc vpc.id
+          end
+        }.to create_an_aws_internet_gateway('test_internet_gateway').and be_idempotent
+        filters = [
+          {:name => 'attachment.vpc-id', :values => [vpc.id]}
+        ]
+        desc_internet_gws = driver.ec2.client.describe_internet_gateways(:filters => filters)[:internet_gateway_set]
+        internet_gateway = driver.ec2.internet_gateways[desc_internet_gws.first[:internet_gateway_id]]
+        expect(desc_internet_gws).not_to be_empty
+      end
+
+      after {
+        if internet_gateway && internet_gateway.exists? && !internet_gateway.vpc.nil?
+          internet_gateway.detach(vpc.id)
+        end
+
+        if vpc && vpc.exists?
+          vpc.delete
+        end
+      }
+    end
+  end
+end


### PR DESCRIPTION
It has working create, update and destroy actions and can receive an options vpc attribute to attach with the internet gateway.

Integration tests included.

References:
http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Internet_Gateway.html
http://docs.aws.amazon.com/AWSRubySDK/latest/AWS/EC2/InternetGateway.html