### PR TITLE
Add aws_vpc_peering_connection.

### DIFF
--- a/lib/chef/provider/aws_vpc_peering_connection.rb
+++ b/lib/chef/provider/aws_vpc_peering_connection.rb
@@ -1,0 +1,88 @@
+require 'chef/provisioning/aws_driver/aws_provider'
+require 'retryable'
+
+class Chef::Provider::AwsVpcPeeringConnection < Chef::Provisioning::AWSDriver::AWSProvider
+  provides :aws_vpc_peering_connection
+
+  def action_create
+    vpc_peering_connection = super
+    accept_connection(vpc_peering_connection, new_resource)
+  end
+
+  def action_accept
+    existing_vpc_peering_connection = new_resource.aws_object
+    accept_connection(existing_vpc_peering_connection, new_resource)
+  end
+
+  protected
+
+  def create_aws_object
+    if new_resource.vpc.nil?
+      raise "VCP peering connection create action for '#{new_resource.name}' requires the 'vpc' attribute."
+    elsif new_resource.peer_vpc.nil?
+      raise "VCP peering connection create action for '#{new_resource.name}' requires the 'peer_vpc' attribute."
+    end
+
+    options = {}
+    options[:vpc_id] = new_resource.vpc
+    options[:peer_vpc_id] = new_resource.peer_vpc
+    options[:peer_owner_id] = new_resource.peer_owner_id unless new_resource.peer_owner_id.nil?
+    options = AWSResource.lookup_options(options, resource: new_resource)
+
+    ec2_resource = new_resource.driver.ec2_resource
+    vpc = ec2_resource.vpc(options[:vpc_id])
+
+    converge_by "create peering connection #{new_resource.name} in VPC #{new_resource.vpc} (#{vpc.id}) and region #{region}" do
+      vpc_peering_connection = vpc.request_vpc_peering_connection(options)
+
+      retry_with_backoff(Aws::EC2::Errors::ServiceError) do
+        ec2_resource.create_tags({
+          :resources => [vpc_peering_connection.id],
+          :tags => [
+            {
+              :key => "Name",
+              :value => new_resource.name
+            }
+          ]
+        })
+      end
+      vpc_peering_connection
+    end
+  end
+
+  def update_aws_object(vpc_peering_connection)
+    vpc_id = vpc_peering_connection.requester_vpc_info.vpc_id
+    peer_vpc_id = vpc_peering_connection.accepter_vpc_info.vpc_id
+    peer_owner_id = vpc_peering_connection.accepter_vpc_info.owner_id
+
+    desired_vpc_id = Chef::Resource::AwsVpc.get_aws_object_id(new_resource.vpc, resource: new_resource)
+    desired_peer_vpc_id = Chef::Resource::AwsVpc.get_aws_object_id(new_resource.peer_vpc, resource: new_resource)
+    desired_peer_owner_id = new_resource.peer_owner_id
+
+    if desired_vpc_id && vpc_id != desired_vpc_id
+      raise "VCP peering connection requester vpc cannot be changed after being created! Desired requester vpc id for #{new_resource.name} (#{vpc_peering_connection.id}) was \"#{desired_vpc_id}\" and actual id is \"#{vpc_id}\""
+    end
+    if desired_peer_vpc_id && peer_vpc_id != desired_peer_vpc_id
+      raise "VCP peering connection accepter vpc cannot be changed after being created! Desired accepter vpc id for #{new_resource.name} (#{vpc_peering_connection.id}) was \"#{desired_peer_vpc_id}\" and actual id is \"#{peer_vpc_id}\""
+    end
+    if desired_peer_owner_id && peer_owner_id != desired_peer_owner_id
+      raise "VCP peering connection accepter owner id vpc cannot be changed after being created! Desired accepter vpc owner id for #{new_resource.name} (#{vpc_peering_connection.id}) was \"#{desired_peer_owner_id}\" and actual owner id is \"#{peer_owner_id}\""
+    end
+  end
+
+  def destroy_aws_object(vpc_peering_connection)
+    converge_by "delete #{new_resource.to_s} in #{region}" do
+      unless ['deleted', 'failed', 'deleting'].include? vpc_peering_connection.status.code
+        vpc_peering_connection.delete
+      end
+    end
+  end
+
+  private
+
+  def accept_connection(vpc_peering_connection, new_resource)
+    if new_resource.peer_owner_id.nil? or new_resource.peer_owner_id == new_resource.driver.account_id
+      vpc_peering_connection.accept
+    end
+  end
+end

--- a/lib/chef/provisioning/aws_driver.rb
+++ b/lib/chef/provisioning/aws_driver.rb
@@ -28,3 +28,5 @@ require "chef/resource/aws_sns_topic"
 require "chef/resource/aws_sqs_queue"
 require "chef/resource/aws_subnet"
 require "chef/resource/aws_vpc"
+require "chef/resource/aws_vpc_peering_connection"
+

--- a/lib/chef/resource/aws_vpc.rb
+++ b/lib/chef/resource/aws_vpc.rb
@@ -27,8 +27,9 @@ require 'chef/provisioning/aws_driver/aws_resource_with_entry'
 #
 class Chef::Resource::AwsVpc < Chef::Provisioning::AWSDriver::AWSResourceWithEntry
   include Chef::Provisioning::AWSDriver::AWSTaggable
-  
-  aws_sdk_type AWS::EC2::VPC
+  aws_sdk_type AWS::EC2::VPC,
+               id: :id,
+               option_names: [:vpc, :vpc_id, :peer_vpc_id]
 
   require 'chef/resource/aws_dhcp_options'
   require 'chef/resource/aws_route_table'

--- a/lib/chef/resource/aws_vpc_peering_connection.rb
+++ b/lib/chef/resource/aws_vpc_peering_connection.rb
@@ -1,0 +1,73 @@
+require 'chef/provisioning/aws_driver/aws_resource_with_entry'
+
+#
+# An AWS peering connection, specifying which VPC to peer.
+#
+# `name` is not guaranteed unique for an AWS account; therefore, Chef will
+# store the vpc peering connection ID associated with this name in your Chef server in the
+# data bag `data/aws_vpc_peering_connection/<name>`.
+#
+# API documentation for the AWS Ruby SDK for VPC Peering Connections can be found here:
+#
+# - http://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Types/VpcPeeringConnectionVpcInfo.html
+#
+class Chef::Resource::AwsVpcPeeringConnection < Chef::Provisioning::AWSDriver::AWSResourceWithEntry
+  aws_sdk_type Aws::EC2::VpcPeeringConnection
+  actions :accept, :create, :destroy, :purge, :nothing
+
+  require 'chef/resource/aws_vpc'
+
+  #
+  # The name of this peering connection.
+  #
+  attribute :name, kind_of: String, name_attribute: true
+
+  #
+  # The Local VPC to peer
+  #
+  # May be one of:
+  # - The name of an `aws_vpc` Chef resource.
+  # - An actual `aws_vpc` resource.
+  # - An AWS `VPC` object.
+  #
+  # This is required for new peering connections.
+  #
+  attribute :vpc, kind_of: [ String, AwsVpc, AWS::EC2::VPC ]
+
+  #
+  # The VPC to peer
+  #
+  # May be one of:
+  # - The name of an `aws_vpc` Chef resource.
+  # - An actual `aws_vpc` resource.
+  # - An AWS `VPC` object.
+  # - The id of an AWS `VPC`.
+  #
+  # This is required for new peering connections.
+  #
+  attribute :peer_vpc, kind_of: [ String, AwsVpc, AWS::EC2::VPC ]
+
+  #
+  # The target VPC account id to peer
+  #
+  # If not specified, will be assumed that the target VPC belongs to the current account.
+  #
+  attribute :peer_owner_id, kind_of: String
+
+  attribute :vpc_peering_connection_id, kind_of: String, aws_id_attribute: true, lazy_default: proc {
+    name =~ /^pcx-[a-f0-9]{8}$/ ? name : nil
+  }
+
+  def aws_object
+    driver, id = get_driver_and_id
+    result = driver.ec2_resource.vpc_peering_connection(id) if id
+
+    begin
+      # try accessing it to find out if it exists
+      result.requester_vpc if result
+    rescue Aws::EC2::Errors::InvalidVpcPeeringConnectionIDNotFound
+      result = nil
+    end
+    result
+  end
+end

--- a/spec/integration/aws_vpc_peering_connection_spec.rb
+++ b/spec/integration/aws_vpc_peering_connection_spec.rb
@@ -1,0 +1,99 @@
+require 'spec_helper'
+
+describe Chef::Resource::AwsVpcPeeringConnection do
+  extend AWSSupport
+
+  when_the_chef_12_server "exists", organization: 'foo', server_scope: :context do
+    with_aws "with 2 VPCs" do
+
+      aws_vpc "test_vpc" do
+        cidr_block '10.0.0.0/24'
+        internet_gateway false
+      end
+
+      aws_vpc "test_vpc_2" do
+        cidr_block '11.0.0.0/24'
+        internet_gateway false
+      end
+
+      it "aws_peering_connection 'test_vpc' with no attributes fails to create a VPC peering connection (must specify vpc and peer_vpc)" do
+        expect_converge {
+          aws_vpc_peering_connection 'test_peering_connection' do
+          end
+        }.to raise_error(RuntimeError, /VCP peering connection create action for 'test_peering_connection' requires the 'vpc' attribute./)
+
+        expect_converge {
+          aws_vpc_peering_connection 'test_peering_connection' do
+            vpc 'test_vpc'
+          end
+        }.to raise_error(RuntimeError, /VCP peering connection create action for 'test_peering_connection' requires the 'peer_vpc' attribute./)
+      end
+
+      it "aws_peering_connection 'test_peering_connection' with minimal parameters creates a active connection" do
+        expect_recipe {
+          aws_vpc_peering_connection 'test_peering_connection' do
+            vpc 'test_vpc'
+            peer_vpc 'test_vpc_2'
+          end
+        }.to create_an_aws_vpc_peering_connection('test_peering_connection',
+          :'requester_vpc_info.vpc_id' => test_vpc.aws_object.id,
+          :'accepter_vpc_info.vpc_id' => test_vpc_2.aws_object.id,
+          :'status.code' => 'active'
+        ).and be_idempotent
+      end
+
+      it "aws_peering_connection 'test_peering_connection' with peer_owner_id set to be the actual account id, creates an active peering" do
+        expect_recipe {
+          aws_vpc_peering_connection 'test_peering_connection' do
+            vpc 'test_vpc'
+            peer_vpc 'test_vpc_2'
+            peer_owner_id driver.account_id
+          end
+        }.to create_an_aws_vpc_peering_connection('test_peering_connection',
+            :'requester_vpc_info.vpc_id' => test_vpc.aws_object.id,
+            :'accepter_vpc_info.vpc_id' => test_vpc_2.aws_object.id,
+            :'status.code' => 'active'
+         ).and be_idempotent
+      end
+
+      it "aws_peering_connection 'test_peering_connection' with a false peer_owner_id, creates a failed peering connection" do
+        expect_recipe {
+          aws_vpc_peering_connection 'test_peering_connection' do
+            vpc 'test_vpc'
+            peer_vpc 'test_vpc_2'
+            peer_owner_id '000000000000'
+          end
+        }.to create_an_aws_vpc_peering_connection('test_peering_connection',
+            :'requester_vpc_info.vpc_id' => test_vpc.aws_object.id,
+            :'accepter_vpc_info.vpc_id' => test_vpc_2.aws_object.id,
+            :'status.code' => 'failed'
+        ).and be_idempotent
+      end
+
+      it "aws_peering_connection 'test_peering_connection' with accept action, accepts a pending peering connection" do
+        pcx = nil
+        ec2_resource = driver.ec2_resource
+        expect_recipe {
+          ruby_block "fetch VPC objects" do
+            block do
+              test_vpc = Chef::Resource::AwsVpc.get_aws_object("test_vpc", run_context: run_context)
+              test_vpc_2 = Chef::Resource::AwsVpc.get_aws_object("test_vpc_2", run_context: run_context)
+              pcx = ec2_resource.vpc(test_vpc.id).request_vpc_peering_connection({ :peer_vpc_id => test_vpc_2.id })
+            end
+          end
+        }.to match_an_aws_vpc_peering_connection(pcx.id,
+           :'status.code' => 'pending-acceptance'
+        )
+
+        expect_recipe {
+          aws_vpc_peering_connection pcx.id do
+            action :accept
+          end
+        }.to match_an_aws_vpc_peering_connection(pcx.id,
+          :'status.code' => 'active'
+        )
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
Added 'create', 'update', and 'destroy' actions for managing vpc peering connections.
Can accept an option to automatically accept a peering connection when the user is the owner of both vpc's.

Updated aws_vpc provider to destroy vpc_peering_requests when vpc is destroyed.
Updated aws_vpc resourse to allow optional names (vpc_id and peer_vpc_id)

Integration tests included.