### PR TITLE
Tagging Refactor Part 1, fixes #281

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --color
 -fd
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,6 @@ gemfile
 gemspec
 
 #gem 'chef-provisioning', path: '../chef-provisioning'
-#gem 'chef-provisioning', github: 'chef/chef-provisioning', branch: 'master'
+gem 'chef-provisioning', github: 'chef/chef-provisioning', branch: 'master'
 #gem "pry-byebug"
 #gem "pry-stack_explorer"

--- a/lib/chef/provider/aws_image.rb
+++ b/lib/chef/provider/aws_image.rb
@@ -4,8 +4,8 @@ class Chef::Provider::AwsImage < Chef::Provisioning::AWSDriver::AWSProvider
   provides :aws_image
 
   def destroy_aws_object(image)
-    instance_id = image.tags['From-Instance']
-    Chef::Log.debug("Found From-Instance tag [#{instance_id}] on #{image.id}")
+    instance_id = image.tags['from-instance']
+    Chef::Log.debug("Found from-instance tag [#{instance_id}] on #{image.id}")
     unless instance_id
       # This is an old image and doesn't have the tag added - lets try and find it from the block device mapping
       image.block_device_mappings.map do |dev, opts|

--- a/lib/chef/provisioning/aws_driver/aws_provider.rb
+++ b/lib/chef/provisioning/aws_driver/aws_provider.rb
@@ -3,6 +3,8 @@ require 'chef/provisioning/aws_driver/aws_resource'
 require 'chef/provisioning/aws_driver/aws_resource_with_entry'
 require 'chef/provisioning/chef_managed_entry_store'
 require 'chef/provisioning/chef_provider_action_handler'
+# Enough providers will require this that we put it in here
+require 'chef/provisioning/aws_driver/tagging_strategy/ec2'
 require 'retryable'
 
 module Chef::Provisioning::AWSDriver
@@ -16,7 +18,7 @@ class AWSProvider < Chef::Provider::LWRPBase
       super("timed out waiting for #{aws_object.id} status to change from #{initial_status.inspect} to #{expected_status.inspect}!")
     end
   end
-  
+
   def action_handler
     @action_handler ||= Chef::Provisioning::ChefProviderActionHandler.new(self)
   end
@@ -121,17 +123,17 @@ class AWSProvider < Chef::Provider::LWRPBase
       aws_object = create_aws_object
     end
 
-    # If the resource hasn't obtained full existence yet this will failed
-    # It could have different errors from different resources
-    retry_with_backoff do
-      converge_tags(aws_object)
-    end
-
     #
     # Associate the managed entry with the AWS object
     #
     if new_resource.is_a?(AWSResourceWithEntry)
       new_resource.save_managed_entry(aws_object, action_handler, existing_entry: entry)
+    end
+
+    # This has to be after the managed entry save so the `aws_object` lookup
+    # from the resource succeeds
+    if respond_to?(:converge_tags)
+      converge_tags
     end
 
     aws_object
@@ -227,46 +229,6 @@ class AWSProvider < Chef::Provider::LWRPBase
     raise NotImplementedError, :destroy_aws_object
   end
 
-  # Update AWS resource tags
-  #
-  # AWS resources which include the TaggedItem Module
-  # will have an 'aws_tags' attribute available.
-  # The 'aws_tags' Hash will apply all the tags within
-  # the hash, and remove existing tags not included within
-  # the hash.  The 'Name' tag will not removed.  The 'Name'
-  # tag can still be updated in the hash.
-  #
-  # @param aws_object Aws SDK Object to update tags
-  #
-  def converge_tags(aws_object)
-    return unless new_resource.respond_to?(:aws_tags)
-    desired_tags = new_resource.aws_tags
-    # If aws_tags were not provided we exit
-    if desired_tags.nil?
-      Chef::Log.debug "aws_tags not provided, nothing to converge"
-      return
-    end
-    current_tags = aws_object.tags.to_h
-    # AWS always returns tags as strings, and we don't want to overwrite a
-    # tag-as-string with the same tag-as-symbol
-    desired_tags = Hash[desired_tags.map {|k, v| [k.to_s, v.to_s] }]
-    tags_to_update = desired_tags.reject {|k,v| current_tags[k] == v}
-    tags_to_delete = current_tags.keys - desired_tags.keys
-    # We don't want to delete `Name`, just all other tags
-    tags_to_delete.delete('Name')
-
-    unless tags_to_update.empty?
-      converge_by "applying tags #{tags_to_update}" do
-        aws_object.tags.set(tags_to_update)
-      end
-    end
-    unless tags_to_delete.empty?
-      converge_by "deleting tags #{tags_to_delete.inspect}" do
-        aws_object.tags.delete(*tags_to_delete)
-      end
-    end
-  end
-
   def wait_for_status(aws_object, expected_status, acceptable_errors = [], tries=60, sleep=5)
     wait_for(
       aws_object: aws_object,
@@ -324,7 +286,7 @@ class AWSProvider < Chef::Provider::LWRPBase
   # @param retry_on [Exception] An exception to retry on, defaults to RuntimeError
   #
   def retry_with_backoff(retry_on = RuntimeError, &block)
-    Retryable.retryable(:tries => 10, :sleep => lambda { |n| [2**n, 10].min }, :on => retry_on, &block)
+    Retryable.retryable(:tries => 10, :sleep => lambda { |n| [2**n, 16].min }, :on => retry_on, &block)
   end
 
 end

--- a/lib/chef/provisioning/aws_driver/aws_rds_resource.rb
+++ b/lib/chef/provisioning/aws_driver/aws_rds_resource.rb
@@ -1,0 +1,11 @@
+require_relative 'aws_resource'
+
+module Chef::Provisioning::AWSDriver
+class AWSRDSResource < AWSResource
+
+  def rds_tagging_type
+    raise "You must add the RDS resource type lookup from http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.html#USER_Tagging.ARN"
+  end
+
+end
+end

--- a/lib/chef/provisioning/aws_driver/aws_resource.rb
+++ b/lib/chef/provisioning/aws_driver/aws_resource.rb
@@ -1,6 +1,8 @@
 require 'aws'
 require 'chef/provisioning/aws_driver/super_lwrp'
 require 'chef/provisioning/chef_managed_entry_store'
+# Enough resources will eventually require this that we put 1 require in here
+require 'chef/provisioning/aws_driver/aws_taggable'
 
 # Common AWS resource - contains metadata that all AWS resources will need
 module Chef::Provisioning::AWSDriver
@@ -65,6 +67,13 @@ class AWSResource < Chef::Provisioning::AWSDriver::SuperLWRP
   #
   def aws_object
     raise NotImplementedError, :aws_object
+  end
+
+  def aws_object_id
+    @aws_object_id ||= begin
+      o = aws_object
+      o.public_send(self.class.aws_sdk_class_id) if o
+    end
   end
 
   #

--- a/lib/chef/provisioning/aws_driver/aws_resource_with_entry.rb
+++ b/lib/chef/provisioning/aws_driver/aws_resource_with_entry.rb
@@ -4,12 +4,6 @@ require 'chef/provisioning/aws_driver/resources'
 # Common AWS resource - contains metadata that all AWS resources will need
 class Chef::Provisioning::AWSDriver::AWSResourceWithEntry < Chef::Provisioning::AWSDriver::AWSResource
 
-  # This should be a hash of tags to apply to the AWS object
-  #
-  # @param aws_tags [Hash] Should be a hash of keys & values to add.  Keys and values
-  #        can be provided as symbols or strings, but will be stored in AWS as strings.
-  attribute :aws_tags, kind_of: Hash
-
   #
   # Dissociate the ID of this object from Chef.
   #

--- a/lib/chef/provisioning/aws_driver/aws_taggable.rb
+++ b/lib/chef/provisioning/aws_driver/aws_taggable.rb
@@ -1,0 +1,18 @@
+module Chef::Provisioning::AWSDriver
+# This module is meant to be included in a resource that is taggable
+# This will add the appropriate attribute that can be converged by the provider
+# TODO it would be nice to not have two seperate modules (taggable/tagger)
+#   and just have the provider decorate the resource or vice versa.  Complicated
+#   by resources <-> providers being many-to-many.
+module AWSTaggable
+
+  def self.included(klass)
+    # This should be a hash of tags to apply to the AWS object
+    #
+    # @param aws_tags [Hash] Should be a hash of keys & values to add.  Keys and values
+    #        can be provided as symbols or strings, but will be stored in AWS as strings.
+    klass.attribute :aws_tags, kind_of: Hash
+  end
+
+end
+end

--- a/lib/chef/provisioning/aws_driver/aws_tagger.rb
+++ b/lib/chef/provisioning/aws_driver/aws_tagger.rb
@@ -1,0 +1,61 @@
+require 'retryable'
+
+module Chef::Provisioning::AWSDriver
+# Include this module on a class or instance that is responsible for tagging
+# itself.  Fill in the hook methods so it knows how to tag itself.
+class AWSTagger
+  extend Forwardable
+
+  attr_reader :action_handler
+
+  def initialize(tagging_strategy, action_handler)
+    @tagging_strategy = tagging_strategy
+    @action_handler = action_handler
+  end
+
+  def_delegators :@tagging_strategy, :desired_tags, :current_tags, :set_tags, :delete_tags
+
+  def converge_tags
+    if desired_tags.nil?
+      Chef::Log.debug "aws_tags not provided, nothing to converge"
+      return
+    end
+
+    # Duplication and normalization
+    # Aws::EC2::Errors::InvalidParameterValue: Tag value cannot be null. Use empty string instead.
+    n_desired_tags = Hash[desired_tags.map {|k,v| [k.to_s, v.to_s]}]
+    n_current_tags = Hash[current_tags.map {|k,v| [k.to_s, v.to_s]}]
+
+    tags_to_set = n_desired_tags.reject {|k,v| n_current_tags[k] && n_current_tags[k] == v}
+    tags_to_delete = n_current_tags.keys - n_desired_tags.keys
+    # We don't want to delete `Name`, just all other tags
+    # Tag keys and values are case sensitive - `Name` is special because it
+    # shows as the name in the console
+    tags_to_delete.delete('Name')
+
+    # Tagging frequently fails so we retry with an exponential backoff, a maximum of 10 seconds
+    Retryable.retryable(
+      :tries => 20,
+      :sleep => lambda { |n| [2**n, 10].min },
+      :on => [AWS::Errors::Base, Aws::Errors::ServiceError,]
+    ) do |retries, exception|
+      if retries > 0
+        Chef::Log.info "Retrying the tagging, previous try failed with #{exception.inspect}"
+      end
+      unless tags_to_set.empty?
+        action_handler.perform_action "creating tags #{tags_to_set}" do
+          set_tags(tags_to_set)
+        end
+        tags_to_set = []
+      end
+      unless tags_to_delete.empty?
+        action_handler.perform_action "deleting tags #{tags_to_delete}" do
+          delete_tags(tags_to_delete)
+        end
+        tags_to_delete = []
+      end
+    end
+  end
+
+end
+end

--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -12,9 +12,12 @@ require 'chef/provisioning/machine/unix_machine'
 require 'chef/provisioning/machine_spec'
 
 require 'chef/provisioning/aws_driver/aws_resource'
+require 'chef/provisioning/aws_driver/tagging_strategy/ec2'
+require 'chef/provisioning/aws_driver/tagging_strategy/elb'
 require 'chef/provisioning/aws_driver/version'
 require 'chef/provisioning/aws_driver/credentials'
 require 'chef/provisioning/aws_driver/credentials2'
+require 'chef/provisioning/aws_driver/aws_tagger'
 
 require 'yaml'
 require 'aws-sdk-v1'
@@ -24,7 +27,7 @@ require 'ubuntu_ami'
 
 # loads the entire aws-sdk
 AWS.eager_autoload!
-AWS_V2_SERVICES = {"EC2" => "ec2"}
+AWS_V2_SERVICES = {"EC2" => "ec2", "S3" => "s3", "ElasticLoadBalancing" => "elb"}
 Aws.eager_autoload!(:services => AWS_V2_SERVICES.keys)
 
 # Need to load the resources after the SDK because `aws_sdk_types` can mess
@@ -33,6 +36,25 @@ require 'chef/resource/aws_key_pair'
 require 'chef/resource/aws_instance'
 require 'chef/resource/aws_image'
 require 'chef/resource/aws_load_balancer'
+
+# We add the appropriate attributes to the base resources for tagging support
+class Chef
+class Resource
+  class Machine
+    include Chef::Provisioning::AWSDriver::AWSTaggable
+  end
+  class MachineImage
+    include Chef::Provisioning::AWSDriver::AWSTaggable
+  end
+  class LoadBalancer
+    include Chef::Provisioning::AWSDriver::AWSTaggable
+  end
+end
+end
+
+Chef::Provider::Machine.additional_machine_option_keys << :aws_tags
+Chef::Provider::MachineImage.additional_image_option_keys << :aws_tags
+Chef::Provider::LoadBalancer.additional_lb_option_keys << :aws_tags
 
 class Chef
 module Provisioning
@@ -91,10 +113,12 @@ module AWSDriver
 
     # Load balancer methods
     def allocate_load_balancer(action_handler, lb_spec, lb_options, machine_specs)
-      lb_options = AWSResource.lookup_options(lb_options || {}, managed_entry_store: lb_spec.managed_entry_store, driver: self)
+      lb_options = (lb_options || {}).to_h
+      lb_options = AWSResource.lookup_options(lb_options, managed_entry_store: lb_spec.managed_entry_store, driver: self)
       # We delete the attributes here because they are not valid in the create call
       # and must be applied afterward
       lb_attributes = lb_options.delete(:attributes)
+      lb_aws_tags = lb_options.delete(:aws_tags)
 
       old_elb = nil
       actual_elb = load_balancer_for(lb_spec)
@@ -114,12 +138,8 @@ module AWSDriver
         updates << "  with security groups #{lb_options[:security_groups]}" if lb_options[:security_groups]
         updates << "  with tags #{lb_options[:aws_tags]}" if lb_options[:aws_tags]
 
-
-        lb_aws_tags = lb_options[:aws_tags]
-        lb_options.delete(:aws_tags)
         action_handler.perform_action updates do
           actual_elb = elb.load_balancers.create(lb_spec.name, lb_options)
-          lb_options[:aws_tags] = lb_aws_tags
 
           lb_spec.reference = {
             'driver_version' => Chef::Provisioning::AWSDriver::VERSION,
@@ -302,34 +322,7 @@ module AWSDriver
         end
       end
 
-      # GRRRR curse you AWS and your crappy tagging support for ELBs
-      read_tags_block = lambda {|aws_object|
-        resp = elb.client.describe_tags load_balancer_names: [aws_object.name]
-        tags = {}
-        resp.data[:tag_descriptions] && resp.data[:tag_descriptions].each do |td|
-          td[:tags].each do |t|
-            tags[t[:key]] = t[:value]
-          end
-        end
-        tags
-      }
-
-      set_tags_block = lambda {|aws_object, desired_tags|
-        aws_form_tags = []
-        desired_tags.each do |k, v|
-          aws_form_tags << {key: k, value: v}
-        end
-        elb.client.add_tags load_balancer_names: [aws_object.name], tags: aws_form_tags
-      }
-
-      delete_tags_block=lambda {|aws_object, tags_to_delete|
-        aws_form_tags = []
-        tags_to_delete.each do |k, v|
-          aws_form_tags << {key: k}
-        end
-        elb.client.remove_tags load_balancer_names: [aws_object.name], tags: aws_form_tags
-      }
-      converge_tags(actual_elb, lb_options[:aws_tags], action_handler, read_tags_block, set_tags_block, delete_tags_block)
+      converge_elb_tags(actual_elb, lb_aws_tags, action_handler)
 
       # Update load balancer attributes
       if lb_attributes
@@ -431,6 +424,8 @@ module AWSDriver
     # Image methods
     def allocate_image(action_handler, image_spec, image_options, machine_spec, machine_options)
       actual_image = image_for(image_spec)
+      image_options = (image_options || {}).to_h.dup
+      machine_options = (machine_options || {}).to_h.dup
       aws_tags = image_options.delete(:aws_tags) || {}
       if actual_image.nil? || !actual_image.exists? || actual_image.state == :failed
         action_handler.perform_action "Create image #{image_spec.name} from machine #{machine_spec.name} with options #{image_options.inspect}" do
@@ -442,13 +437,14 @@ module AWSDriver
           image_spec.reference = {
             'driver_version' => Chef::Provisioning::AWSDriver::VERSION,
             'image_id' => actual_image.id,
-            'allocated_at' => Time.now.to_i
+            'allocated_at' => Time.now.to_i,
+            'from-instance' => image_options[:instance_id]
           }
           image_spec.driver_url = driver_url
         end
       end
-      aws_tags['From-Instance'] = image_options[:instance_id] if image_options[:instance_id]
-      converge_tags(actual_image, aws_tags, action_handler)
+      aws_tags['from-instance'] = image_options[:instance_id] if image_options[:instance_id]
+      converge_ec2_tags(actual_image, aws_tags, action_handler)
     end
 
     def ready_image(action_handler, image_spec, image_options)
@@ -456,11 +452,13 @@ module AWSDriver
       if actual_image.nil? || !actual_image.exists?
         raise 'Cannot ready an image that does not exist'
       else
+        image_options = (image_options || {}).to_h.dup
+        aws_tags = image_options.delete(:aws_tags) || {}
+        aws_tags['from-instance'] = image_spec.reference['from-instance'] if image_spec.reference['from-instance']
+        converge_ec2_tags(actual_image, aws_tags, action_handler)
         if actual_image.state != :available
           action_handler.report_progress 'Waiting for image to be ready ...'
           wait_until_ready_image(action_handler, image_spec, actual_image)
-        else
-          action_handler.report_progress "Image #{image_spec.name} is ready!"
         end
       end
     end
@@ -504,11 +502,10 @@ EOD
       if instance == nil || !instance.exists? || instance.state.name == "terminated"
         action_handler.perform_action "Create #{machine_spec.name} with AMI #{bootstrap_options[:image_id]} in #{aws_config.region}" do
           Chef::Log.debug "Creating instance with bootstrap options #{bootstrap_options}"
-
           instance = create_instance_and_reference(bootstrap_options, action_handler, machine_spec, machine_options)
         end
       end
-
+      converge_ec2_tags(instance, machine_options[:aws_tags], action_handler)
     end
 
     def allocate_machines(action_handler, specs_and_options, parallelizer)
@@ -520,7 +517,7 @@ EOD
 
     def ready_machine(action_handler, machine_spec, machine_options)
       instance = instance_for(machine_spec)
-      converge_tags(instance, machine_options[:aws_tags], action_handler)
+      converge_ec2_tags(instance, machine_options[:aws_tags], action_handler)
 
       if instance.nil?
         raise "Machine #{machine_spec.name} does not have an instance associated with it, or instance does not exist."
@@ -1051,7 +1048,7 @@ EOD
           else
             # Even though the instance has been created the tags could be incorrect if it
             # was created before tags were introduced
-            converge_tags(instance, machine_options[:aws_tags], action_handler)
+            converge_ec2_tags(instance, machine_options[:aws_tags], action_handler)
             yield machine_spec, instance if block_given?
             next
           end
@@ -1084,6 +1081,7 @@ EOD
 
             clean_bootstrap_options = Marshal.load(Marshal.dump(bootstrap_options))
             instance = create_instance_and_reference(clean_bootstrap_options, action_handler, machine_spec, machine_options)
+            converge_ec2_tags(instance, machine_options[:aws_tags], action_handler)
 
             action_handler.performed_action "machine #{machine_spec.name} created as #{instance.id} on #{driver_url}"
 
@@ -1097,41 +1095,24 @@ EOD
       end.to_a
     end
 
-    # TODO This is currently duplicated from AWS Provider
-    # Set the tags on the aws object to desired_tags, while ignoring any `Name` tag
-    # If no tags need to be modified, will not perform a write call on AWS
-    def converge_tags(
-      aws_object,
-      desired_tags,
-      action_handler,
-      read_tags_block=lambda {|aws_object| aws_object.tags.to_h},
-      set_tags_block=lambda {|aws_object, desired_tags| aws_object.tags.set(desired_tags) },
-      delete_tags_block=lambda {|aws_object, tags_to_delete| aws_object.tags.delete(*tags_to_delete) }
-    )
-      # If aws_tags were not provided we exit
-      if desired_tags.nil?
-        Chef::Log.debug "aws_tags not provided, nothing to converge"
-        return
-      end
-      current_tags = read_tags_block.call(aws_object)
-      # AWS always returns tags as strings, and we don't want to overwrite a
-      # tag-as-string with the same tag-as-symbol
-      desired_tags = Hash[desired_tags.map {|k, v| [k.to_s, v.to_s] }]
-      tags_to_update = desired_tags.reject {|k,v| current_tags[k] == v}
-      tags_to_delete = current_tags.keys - desired_tags.keys
-      # We don't want to delete `Name`, just all other tags
-      tags_to_delete.delete('Name')
+    def converge_ec2_tags(aws_object, tags, action_handler)
+      ec2_strategy = Chef::Provisioning::AWSDriver::TaggingStrategy::EC2.new(
+        ec2_client,
+        aws_object.id,
+        tags
+      )
+      aws_tagger = Chef::Provisioning::AWSDriver::AWSTagger.new(ec2_strategy, action_handler)
+      aws_tagger.converge_tags
+    end
 
-      unless tags_to_update.empty?
-        action_handler.perform_action "applying tags #{tags_to_update}" do
-          set_tags_block.call(aws_object, tags_to_update)
-        end
-      end
-      unless tags_to_delete.empty?
-        action_handler.perform_action "deleting tags #{tags_to_delete.inspect}" do
-          delete_tags_block.call(aws_object, tags_to_delete)
-        end
-      end
+    def converge_elb_tags(aws_object, tags, action_handler)
+      elb_strategy = Chef::Provisioning::AWSDriver::TaggingStrategy::ELB.new(
+        elb_client,
+        aws_object.name,
+        tags
+      )
+      aws_tagger = Chef::Provisioning::AWSDriver::AWSTagger.new(elb_strategy, action_handler)
+      aws_tagger.converge_tags
     end
 
     def create_instance_and_reference(bootstrap_options, action_handler, machine_spec, machine_options)
@@ -1170,7 +1151,6 @@ EOD
       %w(is_windows ssh_username sudo transport_address_location ssh_gateway).each do |key|
         machine_spec.reference[key] = machine_options[key.to_sym] if machine_options[key.to_sym]
       end
-      converge_tags(instance, machine_options[:aws_tags], action_handler)
       instance
     end
 

--- a/lib/chef/provisioning/aws_driver/tagging_strategy/ec2.rb
+++ b/lib/chef/provisioning/aws_driver/tagging_strategy/ec2.rb
@@ -1,0 +1,64 @@
+require 'chef/provisioning/aws_driver/aws_tagger'
+
+module Chef::Provisioning::AWSDriver::TaggingStrategy
+  module EC2ConvergeTags
+    def aws_tagger
+      @aws_tagger ||= begin
+        ec2_strategy = Chef::Provisioning::AWSDriver::TaggingStrategy::EC2.new(
+          new_resource.driver.ec2_client,
+          new_resource.aws_object_id,
+          new_resource.aws_tags
+        )
+        Chef::Provisioning::AWSDriver::AWSTagger.new(ec2_strategy, action_handler)
+      end
+    end
+    def converge_tags
+      aws_tagger.converge_tags
+    end
+  end
+end
+
+module Chef::Provisioning::AWSDriver::TaggingStrategy
+class EC2
+
+  attr_reader :ec2_client, :aws_object_id, :desired_tags
+
+  def initialize(ec2_client, aws_object_id, desired_tags)
+    @ec2_client = ec2_client
+    @aws_object_id = aws_object_id
+    @desired_tags = desired_tags
+  end
+
+  def current_tags
+    # http://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Client.html#describe_tags-instance_method
+    resp = ec2_client.describe_tags({
+      filters: [
+        {
+          name: "resource-id",
+          values: [aws_object_id]
+        }
+      ]
+    })
+    Hash[resp.tags.map {|t| [t.key, t.value]}]
+  end
+
+  def set_tags(tags)
+    # http://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Client.html#create_tags-instance_method
+    # "The value parameter is required, but if you don't want the tag to have a value, specify
+    #   the parameter with no value, and we set the value to an empty string."
+    ec2_client.create_tags({
+      resources: [aws_object_id],
+      tags: tags.map {|k,v| {key: k, value: v} }
+    })
+  end
+
+  def delete_tags(tag_keys)
+    # http://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Client.html#delete_tags-instance_method
+    ec2_client.delete_tags({
+      resources: [aws_object_id],
+      tags: tag_keys.map {|k| {key: k} }
+    })
+  end
+
+end
+end

--- a/lib/chef/provisioning/aws_driver/tagging_strategy/elb.rb
+++ b/lib/chef/provisioning/aws_driver/tagging_strategy/elb.rb
@@ -1,0 +1,39 @@
+require 'chef/provisioning/aws_driver/aws_tagger'
+
+module Chef::Provisioning::AWSDriver::TaggingStrategy
+class ELB
+
+  attr_reader :elb_client, :access_point_name, :desired_tags
+
+  def initialize(elb_client, access_point_name, desired_tags)
+    @elb_client = elb_client
+    @access_point_name = access_point_name
+    @desired_tags = desired_tags
+  end
+
+  def current_tags
+    # http://docs.aws.amazon.com/sdkforruby/api/Aws/ElasticLoadBalancing/Client.html#describe_tags-instance_method
+    resp = elb_client.describe_tags({
+      load_balancer_names: [access_point_name]
+    })
+    Hash[resp.tag_descriptions[0].tags.map {|t| [t.key, t.value]}]
+  end
+
+  def set_tags(tags)
+    # http://docs.aws.amazon.com/sdkforruby/api/Aws/ElasticLoadBalancing/Client.html#add_tags-instance_method
+    elb_client.add_tags({
+      load_balancer_names: [access_point_name],
+      tags: tags.map {|k,v| {key: k, value: v} }
+    })
+  end
+
+  def delete_tags(tag_keys)
+    # http://docs.aws.amazon.com/sdkforruby/api/Aws/ElasticLoadBalancing/Client.html#remove_tags-instance_method
+    elb_client.remove_tags({
+      load_balancer_names: [access_point_name],
+      tags: tag_keys.map {|k| {key: k} }
+    })
+  end
+
+end
+end

--- a/lib/chef/provisioning/aws_driver/tagging_strategy/rds.rb
+++ b/lib/chef/provisioning/aws_driver/tagging_strategy/rds.rb
@@ -1,0 +1,92 @@
+require 'chef/provisioning/aws_driver/aws_tagger'
+
+####################
+# NOTE FROM http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.html
+# "Note that tags are cached for authorization purposes. Because of this, additions
+#  and updates to tags on Amazon RDS resources may take several minutes before they
+#  are available."
+####################
+
+module Chef::Provisioning::AWSDriver::TaggingStrategy
+  module RDSConvergeTags
+    def aws_tagger
+      @aws_tagger ||= begin
+        rds_strategy = Chef::Provisioning::AWSDriver::TaggingStrategy::RDS.new(
+          new_resource.driver.rds.client,
+          construct_arn(new_resource),
+          new_resource.aws_tags
+        )
+        Chef::Provisioning::AWSDriver::AWSTagger.new(rds_strategy, action_handler)
+      end
+    end
+    def converge_tags
+      aws_tagger.converge_tags
+    end
+
+    # http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.html#USER_Tagging.ARN
+    def construct_arn(new_resource)
+      @arn ||= begin
+        region = new_resource.driver.aws_config.region
+        name = new_resource.name
+        rds_type = new_resource.rds_tagging_type
+        # Taken from example on https://forums.aws.amazon.com/thread.jspa?threadID=108012
+        account_id = begin
+          u = new_resource.driver.iam.client.get_user
+          # We've got an AWS account root credential or an IAM admin with access rights
+          u[:user][:arn].match('^arn:aws:iam::([0-9]{12}):.*$')[1]
+        rescue AWS::IAM::Errors::AccessDenied => e
+          # We've got an AWS IAM Credential
+          e.to_s.match('^User: arn:aws:iam::([0-9]{12}):.*$')[1]
+        end
+        # arn:aws:rds:<region>:<account number>:<resourcetype>:<name>
+        "arn:aws:rds:#{region}:#{account_id}:#{rds_type}:#{name}"
+      end
+    end
+  end
+end
+
+module Chef::Provisioning::AWSDriver::TaggingStrategy
+class RDS
+
+  attr_reader :rds_client, :rds_object_arn, :desired_tags
+
+  def initialize(rds_client, rds_object_arn, desired_tags)
+    @rds_client = rds_client
+    @rds_object_arn = rds_object_arn
+    @desired_tags = desired_tags
+  end
+
+  def current_tags
+    # http://docs.aws.amazon.com/sdkforruby/api/Aws/RDS/Client.html#list_tags_for_resource-instance_method
+    resp = rds_client.list_tags_for_resource({
+      resource_name: rds_object_arn
+    })
+    Hash[resp.tag_list.map {|t| [t.key, t.value]}]
+  end
+
+  def set_tags(tags)
+    # http://docs.aws.amazon.com/sdkforruby/api/Aws/RDS/Client.html#add_tags_to_resource-instance_method
+    # Unlike EC2, RDS tags can have a nil value
+    tags = tags.map {|k,v|
+      if v.nil?
+        {key: k}
+      else
+        {key: k, value: v}
+      end
+    }
+    rds_client.add_tags_to_resource({
+      resource_name: rds_object_arn,
+      tags: tags
+    })
+  end
+
+  def delete_tags(tag_keys)
+    # http://docs.aws.amazon.com/sdkforruby/api/Aws/RDS/Client.html#remove_tags_from_resource-instance_method
+    rds_client.remove_tags_from_resource({
+      resource_name: rds_object_arn,
+      tag_keys: tag_keys
+    })
+  end
+
+end
+end

--- a/lib/chef/provisioning/aws_driver/tagging_strategy/s3.rb
+++ b/lib/chef/provisioning/aws_driver/tagging_strategy/s3.rb
@@ -1,0 +1,41 @@
+require 'chef/provisioning/aws_driver/aws_tagger'
+module Chef::Provisioning::AWSDriver::TaggingStrategy
+class S3
+
+  attr_reader :s3_client, :bucket_name, :desired_tags
+
+  def initialize(s3_client, bucket_name, desired_tags)
+    @s3_client = s3_client
+    @bucket_name = bucket_name
+    @desired_tags = desired_tags
+  end
+
+  def current_tags
+    # http://docs.aws.amazon.com/sdkforruby/api/Aws/S3/Client.html#get_bucket_tagging-instance_method
+    resp = s3_client.get_bucket_tagging({
+      bucket: bucket_name
+    })
+    Hash[resp.tag_set.map {|t| [t.key, t.value]}]
+  rescue Aws::S3::Errors::NoSuchTagSet => e
+    # Instead of returning nil or empty, AWS raises an error :)
+    {}
+  end
+
+  def set_tags(tags)
+    # http://docs.aws.amazon.com/sdkforruby/api/Aws/S3/Client.html#put_bucket_tagging-instance_method
+    s3_client.put_bucket_tagging({
+      bucket: bucket_name,
+      tagging: {
+        tag_set: tags.map {|k,v| {key: k, value: v} }
+      }
+    })
+  end
+
+  def delete_tags(tag_keys)
+    # S3 doesn't have a client action for deleting individual tags, just ALL tags.  But the
+    # put_bucket_tagging method will set the tags to what is provided so we don't need to
+    # worry about this
+  end
+
+end
+end

--- a/lib/chef/resource/aws_eip_address.rb
+++ b/lib/chef/resource/aws_eip_address.rb
@@ -6,9 +6,6 @@ class Chef::Resource::AwsEipAddress < Chef::Provisioning::AWSDriver::AWSResource
 
   attribute :name, kind_of: String, name_attribute: true
 
-  # guh - every other AWSResourceWithEntry accepts tags EXCEPT this one
-  undef_method(:aws_tags)
-
   # TODO network interface
   attribute :machine,          kind_of: [String, FalseClass]
   attribute :associate_to_vpc, kind_of: [TrueClass, FalseClass]

--- a/lib/chef/resource/aws_instance.rb
+++ b/lib/chef/resource/aws_instance.rb
@@ -7,9 +7,6 @@ class Chef::Resource::AwsInstance < Chef::Provisioning::AWSDriver::AWSResourceWi
     managed_entry_type: :machine,
     managed_entry_id_name: 'instance_id'
 
-  # TODO need to remove this for now because the SDK V2 uses a different tagging mechanism
-  undef_method(:aws_tags)
-
   attribute :name, kind_of: String, name_attribute: true
 
   attribute :instance_id, kind_of: String, aws_id_attribute: true, lazy_default: proc {

--- a/spec/aws_support/matchers/have_aws_object_tags.rb
+++ b/spec/aws_support/matchers/have_aws_object_tags.rb
@@ -34,9 +34,9 @@ module AWSSupport
 
         # Check existence
         if @aws_object.nil?
-          differences << "#{resource_name}[#{name}] did not exist!"
+          differences << "#{resource.to_s} did not exist!"
         else
-          differences += match_hashes_failure_messages(expected_tags, aws_object_tags, "#{resource_name}[#{name}]")
+          differences += match_hashes_failure_messages(expected_tags, aws_object_tags(resource), resource.to_s)
         end
 
         differences
@@ -44,25 +44,14 @@ module AWSSupport
 
       private
 
-      def aws_object_tags
-        if @aws_object.is_a? AWS::ELB::LoadBalancer
-          resp = @example.driver.elb.client.describe_tags load_balancer_names: [@aws_object.name]
-          tags = {}
-          resp.data[:tag_descriptions] && resp.data[:tag_descriptions].each do |td|
-            td[:tags].each do |t|
-              tags[t[:key]] = t[:value]
-            end
-          end
-          tags
-        else
-          tags = @aws_object.tags
-          if tags.is_a? AWS::EC2::ResourceTagCollection
-            tags.to_h
-          else
-            Hash[tags.map {|o| [o.key, o.value]}]
-          end
-        end
+      def aws_object_tags(resource)
+        # Okay, its annoying to have to lookup the provider for a resource and duplicate a bunch of code here.
+        # But I don't want to move the `converge_tags` method into the resource and until the resource & provider
+        # are combined, this is my best idea.
+        provider = resource.provider_for_action(:create)
+        provider.aws_tagger.current_tags
       end
+
     end
   end
 end


### PR DESCRIPTION
This replaces https://github.com/chef/chef-provisioning-aws/pull/299.  I split it into 2 reviews - this first one shows the architectural changes to enable the tagging refactor.

If a resource wants to use tagging it needs to add the `aws_tags` attribute.  For all the non-base resources this is done by including the `Chef::Provisioning::AWSDriver::AWSTaggable` module.  The base resources are modified by adding the module _and_ adding `aws_tags` to their  `additional_*_options` list.  This means the resource will get passed to the driver as part of the `*_options` hash passed to the hook methods.

For a resource to use tagging it needs to add the `converge_tags` method.  The base `AWSProvider` class will then call that method after converging the resource.  I introduced an `AWSTagger` class which has a `converge_tags` method that knows how to diff current tags from desired tags and converge them.  Because every AWS client handles this differently, I use a strategy pattern to supply the exact logic for each resource.

TODO
- [x] README & CHANGELOG updates