### PR TITLE
specs for dynamic options in machine_batch, per chef-provisioning#438

### DIFF
--- a/spec/integration/machine_batch_spec.rb
+++ b/spec/integration/machine_batch_spec.rb
@@ -12,16 +12,27 @@ describe Chef::Resource::MachineBatch do
 
       purge_all
       setup_public_vpc
+
+      azs = []
+      driver.ec2.availability_zones.each {|az| azs << az }
+      az = azs[1].name
+      aws_subnet 'test_subnet2' do
+        vpc 'test_vpc'
+        cidr_block '10.0.1.0/24'
+        availability_zone az
+        map_public_ip_on_launch true
+      end
+
       it "machine_batch creates multiple machines", :super_slow do
         expect_recipe {
           machine_batch 'test_machines' do
+            action :allocate
             (1..3).each do |i|
               machine "test_machine#{i}" do
                 machine_options bootstrap_options: {
                   subnet_id: 'test_public_subnet',
                   key_name: 'test_key_pair'
                 }, source_dest_check: false
-                action :allocate
               end
             end
             action :allocate
@@ -31,6 +42,30 @@ describe Chef::Resource::MachineBatch do
         ).and create_an_aws_instance('test_machine2',
           source_dest_check: false
         ).and create_an_aws_instance('test_machine3',
+          source_dest_check: false
+        ).and be_idempotent
+      end
+
+      it "machine_batch supports runtime machine_options", :super_slow do
+        expect_recipe {
+          subnets = %w(test_public_subnet test_subnet2)
+
+          machine_batch 'test_machines' do
+            action :allocate
+            (1..2).each do |i|
+              machine "test_machine#{i}" do
+                machine_options bootstrap_options: {
+                  subnet_id: subnets[i-1],
+                  key_name: 'test_key_pair'
+                }, source_dest_check: (i == 1)
+              end
+            end
+          end
+        }.to create_an_aws_instance('test_machine1',
+          subnet_id: test_public_subnet.aws_object.id,
+          source_dest_check: true
+        ).and create_an_aws_instance('test_machine2',
+          subnet_id: test_subnet2.aws_object.id,
           source_dest_check: false
         ).and be_idempotent
       end


### PR DESCRIPTION
Two things here:
1. The `action` the existing spec was moved from `machine` to `machine_batch`.  The latter is in control (bug/feature?  not clear!) in this context, so I think this is just a bug in the test.
2. Add a spec for dynamic options used in `machine_batch`, which ought to also serve as an example of how to dynamically choose a subnet/az for a new node.

As mentioned in [chef-provisioning#438](https://github.com/chef/chef-provisioning/issues/438), I was hoping this spec would fail and shed some light on why it fails in my real recipe, but it passes.  Yay?
