### PR TITLE
Updating to support chef master

### DIFF
--- a/chef-provisioning-aws.gemspec
+++ b/chef-provisioning-aws.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   # chef-zero is only a development dependency because we leverage its RSpec support
   s.add_development_dependency 'chef-zero', '~> 4.2'
-  s.add_development_dependency 'chef', '>= 11.16.4'
+  s.add_development_dependency 'chef', '~> 12.4'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'pry'

--- a/lib/chef/provider/aws_vpc.rb
+++ b/lib/chef/provider/aws_vpc.rb
@@ -5,7 +5,7 @@ require 'retryable'
 
 class Chef::Provider::AwsVpc < Chef::Provisioning::AWSDriver::AWSProvider
   include Chef::Provisioning::AWSDriver::TaggingStrategy::EC2ConvergeTags
-  
+
   provides :aws_vpc
 
   class NeverObtainedExistence < RuntimeError; end
@@ -247,9 +247,11 @@ class Chef::Provider::AwsVpc < Chef::Provisioning::AWSDriver::AWSProvider
     # creating the VPC
     main_route_table ||= vpc.route_tables.main_route_table
     main_routes = new_resource.main_routes
-    aws_route_table main_route_table.id do
-      vpc vpc
-      routes main_routes
+    Cheffish.inline_resource(self, action) do
+      aws_route_table main_route_table.id do
+        vpc vpc
+        routes main_routes
+      end
     end
     main_route_table
   end

--- a/lib/chef/provisioning/aws_driver.rb
+++ b/lib/chef/provisioning/aws_driver.rb
@@ -30,3 +30,22 @@ require "chef/resource/aws_subnet"
 require "chef/resource/aws_vpc"
 require "chef/resource/aws_vpc_peering_connection"
 
+module NoResourceCloning
+  def prior_resource
+    if resource_class <= Chef::Provisioning::AWSDriver::AWSResource
+      Chef::Log.debug "Canceling resource cloning for #{resource_class}"
+      nil
+    else
+      super
+    end
+  end
+  def emit_cloned_resource_warning; end
+  def emit_harmless_cloning_debug; end
+end
+
+# Chef 12.2 changed `load_prior_resource` logic to be in the Chef::ResourceBuilder class
+# but that class only exists in 12.2 and up
+if defined? Chef::ResourceBuilder
+  # Ruby 2.0.0 has prepend as a protected method
+  Chef::ResourceBuilder.send(:prepend, NoResourceCloning)
+end

--- a/lib/chef/provisioning/aws_driver/aws_resource.rb
+++ b/lib/chef/provisioning/aws_driver/aws_resource.rb
@@ -5,199 +5,208 @@ require 'chef/provisioning/chef_managed_entry_store'
 require 'chef/provisioning/aws_driver/aws_taggable'
 
 # Common AWS resource - contains metadata that all AWS resources will need
-module Chef::Provisioning::AWSDriver
-class AWSResource < Chef::Provisioning::AWSDriver::SuperLWRP
-  actions :create, :destroy, :purge, :nothing
-  default_action :create
+class Chef
+module Provisioning
+module AWSDriver
 
-  def initialize(name, run_context=nil)
-    name = name.public_send(self.class.aws_sdk_class_id) if name.is_a?(self.class.aws_sdk_class)
-    super
-    if run_context
-      driver run_context.chef_provisioning.current_driver
-      chef_server run_context.cheffish.current_chef_server
-    end
-  end
+  class AWSResource < Chef::Provisioning::AWSDriver::SuperLWRP
+    actions :create, :destroy, :purge, :nothing
+    default_action :create
 
-  # Backwards compatibility for action :destroy
-  def action(*args)
-    if args == [ :delete ]
-      super(:destroy)
-    else
+    def initialize(name, run_context=nil)
+      name = name.public_send(self.class.aws_sdk_class_id) if name.is_a?(self.class.aws_sdk_class)
       super
-    end
-  end
-
-  # In Chef < 12.4 we need to define this method.  In > 12.4 this method is
-  # already defined for us so we don't need to overwrite it.
-  unless defined?(:action=)
-    def action=(value)
-      action(value)
-    end
-  end
-
-  #
-  # The desired driver.
-  #
-  attribute :driver, kind_of: Chef::Provisioning::Driver,
-                     coerce: (proc do |value|
-                               case value
-                               when nil, Chef::Provisioning::Driver
-                                 value
-                               else
-                                 run_context.chef_provisioning.driver_for(value)
-                               end
-                             end)
-
-  #
-  # The Chef server on which any IDs should be looked up.
-  #
-  attribute :chef_server, kind_of: Hash
-
-  #
-  # The managed entry store.
-  #
-  attribute :managed_entry_store, kind_of: Chef::Provisioning::ManagedEntryStore,
-                              lazy_default: proc { Chef::Provisioning::ChefManagedEntryStore.new(chef_server) }
-
-  #
-  # Get the current AWS object.  This should return the aws_object even if it has
-  # a status like 'deleted' or 'inactive'.  If there is an aws_object, we return it.
-  # Callers will need to check the status if they care.
-  #
-  def aws_object
-    raise NotImplementedError, :aws_object
-  end
-
-  def aws_object_id
-    @aws_object_id ||= begin
-      o = aws_object
-      o.public_send(self.class.aws_sdk_class_id) if o
-    end
-  end
-
-  #
-  # Look up an AWS options list, translating standard names using the appropriate
-  # classes.
-  #
-  # For example, `load_balancer_options` is passed into `lookup_options`, and if
-  # it looks like this: `{ subnets: `[ 'subnet1', 'subnet2' ] }`, then
-  # `AWSResource.lookup_options` will translate each ID with
-  # `AwsSubnet.get_aws_object('subnet1')`, which supports Chef names
-  # (`mysubnet`) as well as AWS subnet Ids (`subnet-1234abcd`) or AWS objects
-  # (`AWS::EC2::Subnet`).
-  #
-  # Keys that represent non-AWS-objects (such as `timeout`) are left alone.
-  #
-  def self.lookup_options(options, **handler_options)
-    options = options.dup
-    options.each do |name, value|
-      if name.to_s.end_with?('s')
-        handler_name = :"#{name[0..-2]}"
-        if aws_option_handlers[handler_name]
-          options[name] = [options[name]].flatten.map { |value| aws_option_handlers[handler_name].get_aws_object_id(value, **handler_options) }
-        end
-      else
-        if aws_option_handlers[name]
-          options[name] = aws_option_handlers[name].get_aws_object_id(value, **handler_options)
-        end
+      if run_context
+        driver run_context.chef_provisioning.current_driver
+        chef_server run_context.cheffish.current_chef_server
       end
     end
-    options
-  end
 
-  def self.get_aws_object(value, resource: nil, run_context: nil, driver: nil, managed_entry_store: nil, required: true)
-    return nil if value.nil?
-
-    if resource
-      run_context         ||= resource.run_context
-      driver              ||= resource.driver
-      managed_entry_store ||= resource.managed_entry_store
-    end
-    if value.is_a?(self)
-      resource = value
-    else
-      resource = new(value, run_context)
-      resource.driver driver if driver
-      resource.managed_entry_store managed_entry_store if managed_entry_store
+    # Backwards compatibility for action :destroy
+    def action(*args)
+      if args == [ :delete ]
+        super(:destroy)
+      else
+        super
+      end
     end
 
-    result = resource.aws_object
-    if required && result.nil?
-      raise "#{self}[#{value}] does not exist!"
-    end
-    result
-  end
-
-  def self.get_aws_object_id(value, **options)
-    aws_object = get_aws_object(value, **options)
-    aws_object.public_send(aws_sdk_class_id) if aws_object
-  end
-
-  protected
-
-  NOT_PASSED = Object.new
-
-  def self.aws_sdk_type(sdk_class,
-                        option_names: nil,
-                        option_name: NOT_PASSED,
-                        load_provider: true,
-                        id: :name,
-                        aws_id_prefix: nil)
-    self.resource_name = convert_to_snake_case(self.name.split('::')[-1])
-    @aws_sdk_class = sdk_class
-    @aws_sdk_class_id = id
-    @aws_id_prefix = aws_id_prefix
-
-    # Go ahead and require the provider since we're here anyway ...
-    require "chef/provider/#{resource_name}" if load_provider
-
-    option_name = :"#{resource_name[4..-1]}" if option_name == NOT_PASSED
-    @aws_sdk_option_name = option_name
-
-    option_names ||= begin
-      option_names = []
-      option_names << aws_sdk_option_name
-      option_names << :"#{option_name}_#{aws_sdk_class_id}" if aws_sdk_class_id
-      option_names
-    end
-    option_names.each do |option_name|
-      aws_option_handlers[option_name] = self
+    # In Chef < 12.4 we need to define this method.  In > 12.4 this method is
+    # already defined for us so we don't need to overwrite it.
+    unless defined?(:action=)
+      def action=(value)
+        action(value)
+      end
     end
 
-    name = self.name.split('::')[-1]
-    eval("Chef::Provisioning::AWSDriver::Resources::#{name} = self", binding, __FILE__, __LINE__)
+    #
+    # The desired driver.
+    #
+    attribute :driver, kind_of: Chef::Provisioning::Driver,
+                       coerce: (proc do |value|
+                                 case value
+                                 when nil, Chef::Provisioning::Driver
+                                   value
+                                 else
+                                   run_context.chef_provisioning.driver_for(value)
+                                 end
+                               end)
+
+    #
+    # The Chef server on which any IDs should be looked up.
+    #
+    attribute :chef_server, kind_of: Hash
+
+    #
+    # The managed entry store.
+    #
+    attribute :managed_entry_store, kind_of: Chef::Provisioning::ManagedEntryStore,
+                                default: lazy { Chef::Provisioning::ChefManagedEntryStore.new(chef_server) }
+
+    #
+    # Get the current AWS object.  This should return the aws_object even if it has
+    # a status like 'deleted' or 'inactive'.  If there is an aws_object, we return it.
+    # Callers will need to check the status if they care.
+    #
+    def aws_object
+      raise NotImplementedError, :aws_object
+    end
+
+    def aws_object_id
+      @aws_object_id ||= begin
+        o = aws_object
+        o.public_send(self.class.aws_sdk_class_id) if o
+      end
+    end
+
+    #
+    # Look up an AWS options list, translating standard names using the appropriate
+    # classes.
+    #
+    # For example, `load_balancer_options` is passed into `lookup_options`, and if
+    # it looks like this: `{ subnets: `[ 'subnet1', 'subnet2' ] }`, then
+    # `AWSResource.lookup_options` will translate each ID with
+    # `AwsSubnet.get_aws_object('subnet1')`, which supports Chef names
+    # (`mysubnet`) as well as AWS subnet Ids (`subnet-1234abcd`) or AWS objects
+    # (`AWS::EC2::Subnet`).
+    #
+    # Keys that represent non-AWS-objects (such as `timeout`) are left alone.
+    #
+    def self.lookup_options(options, **handler_options)
+      options = options.dup
+      options.each do |name, value|
+        if name.to_s.end_with?('s')
+          handler_name = :"#{name[0..-2]}"
+          if aws_option_handlers[handler_name]
+            options[name] = [options[name]].flatten.map { |value| aws_option_handlers[handler_name].get_aws_object_id(value, **handler_options) }
+          end
+        else
+          if aws_option_handlers[name]
+            options[name] = aws_option_handlers[name].get_aws_object_id(value, **handler_options)
+          end
+        end
+      end
+      options
+    end
+
+    def self.get_aws_object(value, resource: nil, run_context: nil, driver: nil, managed_entry_store: nil, required: true)
+      return nil if value.nil?
+
+      if resource
+        run_context         ||= resource.run_context
+        driver              ||= resource.driver
+        managed_entry_store ||= resource.managed_entry_store
+      end
+      if value.is_a?(self)
+        resource = value
+      else
+        resource = new(value, run_context)
+        resource.driver driver if driver
+        resource.managed_entry_store managed_entry_store if managed_entry_store
+      end
+
+      result = resource.aws_object
+      if required && result.nil?
+        raise "#{self}[#{value}] does not exist!"
+      end
+      result
+    end
+
+    def self.get_aws_object_id(value, **options)
+      aws_object = get_aws_object(value, **options)
+      aws_object.public_send(aws_sdk_class_id) if aws_object
+    end
+
+    protected
+
+    # This supports the introduction of the NOT_PASSED chef constant
+    # in chef 12.5
+    # TODO remove when we make 12.5 and higher a dependency
+    NOT_PASSED = Object.new unless defined?(NOT_PASSED)
+
+    def self.aws_sdk_type(sdk_class,
+                          option_names: nil,
+                          option_name: NOT_PASSED,
+                          load_provider: true,
+                          id: :name,
+                          aws_id_prefix: nil)
+      self.resource_name = convert_to_snake_case(self.name.split('::')[-1])
+      @aws_sdk_class = sdk_class
+      @aws_sdk_class_id = id
+      @aws_id_prefix = aws_id_prefix
+
+      # Go ahead and require the provider since we're here anyway ...
+      require "chef/provider/#{resource_name}" if load_provider
+
+      option_name = :"#{resource_name[4..-1]}" if option_name == NOT_PASSED
+      @aws_sdk_option_name = option_name
+
+      option_names ||= begin
+        option_names = []
+        option_names << aws_sdk_option_name
+        option_names << :"#{option_name}_#{aws_sdk_class_id}" if aws_sdk_class_id
+        option_names
+      end
+      option_names.each do |option_name|
+        aws_option_handlers[option_name] = self
+      end
+
+      name = self.name.split('::')[-1]
+      eval("Chef::Provisioning::AWSDriver::Resources::#{name} = self", binding, __FILE__, __LINE__)
+    end
+
+    def self.aws_sdk_class
+      @aws_sdk_class
+    end
+
+    def self.aws_sdk_class_id
+      @aws_sdk_class_id
+    end
+
+    def self.aws_id_prefix
+      @aws_id_prefix
+    end
+
+    def self.aws_sdk_option_name
+      @aws_sdk_option_name
+    end
+
+    @@aws_option_handlers = {}
+    def self.aws_option_handlers
+      @@aws_option_handlers
+    end
+
+    # Add support for aws_id_attribute: true
+    def self.attribute(name, aws_id_attribute: false, **validation_opts)
+      @aws_id_attribute = name if aws_id_attribute
+      super(name, validation_opts)
+    end
+
+    def self.aws_id_attribute
+      @aws_id_attribute
+    end
   end
 
-  def self.aws_sdk_class
-    @aws_sdk_class
-  end
-
-  def self.aws_sdk_class_id
-    @aws_sdk_class_id
-  end
-
-  def self.aws_id_prefix
-    @aws_id_prefix
-  end
-
-  def self.aws_sdk_option_name
-    @aws_sdk_option_name
-  end
-
-  @@aws_option_handlers = {}
-  def self.aws_option_handlers
-    @@aws_option_handlers
-  end
-
-  # Add support for aws_id_attribute: true
-  def self.attribute(name, aws_id_attribute: false, **validation_opts)
-    @aws_id_attribute = name if aws_id_attribute
-    super(name, validation_opts)
-  end
-
-  def self.aws_id_attribute
-    @aws_id_attribute
-  end
+end
 end
 end

--- a/lib/chef/provisioning/aws_driver/super_lwrp.rb
+++ b/lib/chef/provisioning/aws_driver/super_lwrp.rb
@@ -5,60 +5,48 @@ module Provisioning
 module AWSDriver
   class SuperLWRP < Chef::Resource::LWRPBase
     #
-    # Add the :lazy_default and :coerce validation_opts to `attribute`
+    # Add the :default lazy { ... } and :coerce validation_opts to `attribute`
     #
-    def self.attribute(attr_name, validation_opts={})
-      lazy_default = validation_opts.delete(:lazy_default)
-      coerce = validation_opts.delete(:coerce)
-      if lazy_default || coerce
-        define_method(attr_name) do |arg=nil|
-          arg = instance_exec(arg, &coerce) if coerce && !arg.nil?
-
-          result = set_or_return(attr_name.to_sym, arg, validation_opts)
-
-          if result.nil? && arg.nil?
-            result = instance_eval(&lazy_default) if lazy_default
-          end
-
-          result
+    if self.respond_to?(:properties)
+      # in Chef 12.5+, properties replace attributes and these respond to
+      # coerce and default with a lazy block - no need for overwriting!
+    else
+      def self.attribute(attr_name, validation_opts={})
+        if validation_opts[:default].is_a?(Chef::DelayedEvaluator)
+          lazy_default = validation_opts.delete(:default)
         end
-        define_method(:"#{attr_name}=") do |arg|
-          if arg.nil?
-            remove_instance_variable(:"@#{arg}")
-          else
-            set_or_return(attr_name.to_sym, arg, validation_opts)
+        coerce = validation_opts.delete(:coerce)
+        if lazy_default || coerce
+          define_method(attr_name) do |arg=nil|
+            arg = instance_exec(arg, &coerce) if coerce && !arg.nil?
+
+            result = set_or_return(attr_name.to_sym, arg, validation_opts)
+
+            if result.nil? && arg.nil?
+              result = instance_eval(&lazy_default) if lazy_default
+            end
+
+            result
           end
+          define_method(:"#{attr_name}=") do |arg|
+            if arg.nil?
+              remove_instance_variable(:"@#{arg}")
+            else
+              set_or_return(attr_name.to_sym, arg, validation_opts)
+            end
+          end
+        else
+          super
         end
-      else
-        super
+      end
+
+      # Below chef 12.5 you cannot do `default lazy: { ... }` - this adds that
+      def self.lazy(&block)
+        Chef::DelayedEvaluator.new(&block)
       end
     end
 
-    # FUUUUUU cloning - this works for Chef 11 or 12.1
-    def load_prior_resource(*args)
-      Chef::Log.debug "Overloading #{self.resource_name} load_prior_resource with NOOP"
-    end
   end
 end
 end
-end
-
-module NoResourceCloning
-  def prior_resource
-    if resource_class <= Chef::Provisioning::AWSDriver::SuperLWRP
-      Chef::Log.debug "Canceling resource cloning for #{resource_class}"
-      nil
-    else
-      super
-    end
-  end
-  def emit_cloned_resource_warning; end
-  def emit_harmless_cloning_debug; end
-end
-
-# Chef 12.2 changed `load_prior_resource` logic to be in the Chef::ResourceBuilder class
-# but that class only exists in 12.2 and up
-if defined? Chef::ResourceBuilder
-  # Ruby 2.0.0 has prepend as a protected method
-  Chef::ResourceBuilder.send(:prepend, NoResourceCloning)
 end

--- a/lib/chef/resource/aws_dhcp_options.rb
+++ b/lib/chef/resource/aws_dhcp_options.rb
@@ -47,7 +47,7 @@ class Chef::Resource::AwsDhcpOptions < Chef::Provisioning::AWSDriver::AWSResourc
   #
   attribute :netbios_node_type, kind_of: Integer
 
-  attribute :dhcp_options_id, kind_of: String, aws_id_attribute: true, lazy_default: proc {
+  attribute :dhcp_options_id, kind_of: String, aws_id_attribute: true, default: lazy {
     name =~ /^dopt-[a-f0-9]{8}$/ ? name : nil
   }
 

--- a/lib/chef/resource/aws_ebs_volume.rb
+++ b/lib/chef/resource/aws_ebs_volume.rb
@@ -19,7 +19,7 @@ class Chef::Resource::AwsEbsVolume < Chef::Provisioning::AWSDriver::AWSResourceW
   attribute :encrypted,         kind_of: [ TrueClass, FalseClass ]
   attribute :device,            kind_of: String
 
-  attribute :volume_id,         kind_of: String, aws_id_attribute: true, lazy_default: proc {
+  attribute :volume_id,         kind_of: String, aws_id_attribute: true, default: lazy {
     name =~ /^vol-[a-f0-9]{8}$/ ? name : nil
   }
 

--- a/lib/chef/resource/aws_eip_address.rb
+++ b/lib/chef/resource/aws_eip_address.rb
@@ -26,7 +26,7 @@ class Chef::Resource::AwsEipAddress < Chef::Provisioning::AWSDriver::AWSResource
   # ```
   #
   attribute :public_ip, kind_of: String, aws_id_attribute: true, coerce: proc { |v| IPAddr.new(v); v },
-    lazy_default: proc {
+    default: lazy {
       begin
         IPAddr.new(name)
         name

--- a/lib/chef/resource/aws_image.rb
+++ b/lib/chef/resource/aws_image.rb
@@ -10,7 +10,7 @@ class Chef::Resource::AwsImage < Chef::Provisioning::AWSDriver::AWSResourceWithE
 
   attribute :name, kind_of: String,  name_attribute: true
 
-  attribute :image_id, kind_of: String, aws_id_attribute: true, lazy_default: proc {
+  attribute :image_id, kind_of: String, aws_id_attribute: true, default: lazy {
     name =~ /^ami-[a-f0-9]{8}$/ ? name : nil
   }
 

--- a/lib/chef/resource/aws_instance.rb
+++ b/lib/chef/resource/aws_instance.rb
@@ -12,7 +12,7 @@ class Chef::Resource::AwsInstance < Chef::Provisioning::AWSDriver::AWSResourceWi
 
   attribute :name, kind_of: String, name_attribute: true
 
-  attribute :instance_id, kind_of: String, aws_id_attribute: true, lazy_default: proc {
+  attribute :instance_id, kind_of: String, aws_id_attribute: true, default: lazy {
     name =~ /^i-[a-f0-9]{8}$/ ? name : nil
   }
 

--- a/lib/chef/resource/aws_internet_gateway.rb
+++ b/lib/chef/resource/aws_internet_gateway.rb
@@ -7,7 +7,7 @@ class Chef::Resource::AwsInternetGateway < Chef::Provisioning::AWSDriver::AWSRes
 
   attribute :name, kind_of: String, name_attribute: true
 
-  attribute :internet_gateway_id, kind_of: String, aws_id_attribute: true, lazy_default: proc {
+  attribute :internet_gateway_id, kind_of: String, aws_id_attribute: true, default: lazy {
     name =~ /^igw-[a-f0-9]{8}$/ ? name : nil
   }
 

--- a/lib/chef/resource/aws_load_balancer.rb
+++ b/lib/chef/resource/aws_load_balancer.rb
@@ -8,7 +8,7 @@ class Chef::Resource::AwsLoadBalancer < Chef::Provisioning::AWSDriver::AWSResour
 
   attribute :name, kind_of: String,  name_attribute: true
 
-  attribute :load_balancer_id, kind_of: String, aws_id_attribute: true, lazy_default: proc {
+  attribute :load_balancer_id, kind_of: String, aws_id_attribute: true, default: lazy {
     name =~ /^elb-[a-f0-9]{8}$/ ? name : nil
   }
 

--- a/lib/chef/resource/aws_network_acl.rb
+++ b/lib/chef/resource/aws_network_acl.rb
@@ -44,7 +44,7 @@ class Chef::Resource::AwsNetworkAcl < Chef::Provisioning::AWSDriver::AWSResource
   attribute :network_acl_id,
             kind_of: String,
             aws_id_attribute: true,
-            lazy_default: proc {
+            default: lazy {
               name =~ /^acl-[a-f0-9]{8}$/ ? name : nil
             }
 

--- a/lib/chef/resource/aws_network_interface.rb
+++ b/lib/chef/resource/aws_network_interface.rb
@@ -9,7 +9,7 @@ class Chef::Resource::AwsNetworkInterface < Chef::Provisioning::AWSDriver::AWSRe
 
   attribute :name,                   kind_of: String, name_attribute: true
 
-  attribute :network_interface_id,   kind_of: String, aws_id_attribute: true, lazy_default: proc {
+  attribute :network_interface_id,   kind_of: String, aws_id_attribute: true, default: lazy {
     name =~ /^eni-[a-f0-9]{8}$/ ? name : nil
   }
 

--- a/lib/chef/resource/aws_route_table.rb
+++ b/lib/chef/resource/aws_route_table.rb
@@ -91,7 +91,7 @@ class Chef::Resource::AwsRouteTable < Chef::Provisioning::AWSDriver::AWSResource
   attribute :ignore_route_targets, kind_of: [ String, Array ], default: [],
             coerce: proc { |v| [v].flatten }
 
-  attribute :route_table_id, kind_of: String, aws_id_attribute: true, lazy_default: proc {
+  attribute :route_table_id, kind_of: String, aws_id_attribute: true, default: lazy {
     name =~ /^rtb-[a-f0-9]{8}$/ ? name : nil
   }
 

--- a/lib/chef/resource/aws_security_group.rb
+++ b/lib/chef/resource/aws_security_group.rb
@@ -49,7 +49,7 @@ class Chef::Resource::AwsSecurityGroup < Chef::Provisioning::AWSDriver::AWSResou
   attribute :inbound_rules,  kind_of: [ Array, Hash ]
   attribute :outbound_rules, kind_of: [ Array, Hash ]
 
-  attribute :security_group_id, kind_of: String, aws_id_attribute: true, lazy_default: proc {
+  attribute :security_group_id, kind_of: String, aws_id_attribute: true, default: lazy {
     name =~ /^sg-[a-f0-9]{8}$/ ? name : nil
   }
 

--- a/lib/chef/resource/aws_sns_topic.rb
+++ b/lib/chef/resource/aws_sns_topic.rb
@@ -4,7 +4,7 @@ class Chef::Resource::AwsSnsTopic < Chef::Provisioning::AWSDriver::AWSResource
   aws_sdk_type AWS::SNS::Topic
 
   attribute :name, kind_of: String, name_attribute: true
-  attribute :arn,  kind_of: String, lazy_default: proc { driver.build_arn(service: 'sns', resource: name) }
+  attribute :arn,  kind_of: String, default: lazy { driver.build_arn(service: 'sns', resource: name) }
 
   def aws_object
     result = driver.sns.topics[arn]

--- a/lib/chef/resource/aws_subnet.rb
+++ b/lib/chef/resource/aws_subnet.rb
@@ -86,7 +86,7 @@ class Chef::Resource::AwsSubnet < Chef::Provisioning::AWSDriver::AWSResourceWith
   #
   attribute :network_acl, kind_of: [ String, AwsNetworkAcl, AWS::EC2::NetworkACL ]
 
-  attribute :subnet_id, kind_of: String, aws_id_attribute: true, lazy_default: proc {
+  attribute :subnet_id, kind_of: String, aws_id_attribute: true, default: lazy {
     name =~ /^subnet-[a-f0-9]{8}$/ ? name : nil
   }
 

--- a/lib/chef/resource/aws_vpc.rb
+++ b/lib/chef/resource/aws_vpc.rb
@@ -128,7 +128,7 @@ class Chef::Resource::AwsVpc < Chef::Provisioning::AWSDriver::AWSResourceWithEnt
   #
   attribute :enable_dns_hostnames, equal_to: [ true, false ]
 
-  attribute :vpc_id, kind_of: String, aws_id_attribute: true, lazy_default: proc {
+  attribute :vpc_id, kind_of: String, aws_id_attribute: true, default: lazy {
     name =~ /^vpc-[a-f0-9]{8}$/ ? name : nil
   }
 

--- a/lib/chef/resource/aws_vpc_peering_connection.rb
+++ b/lib/chef/resource/aws_vpc_peering_connection.rb
@@ -54,7 +54,7 @@ class Chef::Resource::AwsVpcPeeringConnection < Chef::Provisioning::AWSDriver::A
   #
   attribute :peer_owner_id, kind_of: String
 
-  attribute :vpc_peering_connection_id, kind_of: String, aws_id_attribute: true, lazy_default: proc {
+  attribute :vpc_peering_connection_id, kind_of: String, aws_id_attribute: true, default: lazy {
     name =~ /^pcx-[a-f0-9]{8}$/ ? name : nil
   }
 

--- a/spec/aws_support.rb
+++ b/spec/aws_support.rb
@@ -96,11 +96,6 @@ module AWSSupport
       aws_driver = Chef::Provisioning.driver_for_url(ENV['AWS_TEST_DRIVER'])
       when_the_repository "exists #{description ? "and #{description}" : ""}", *tags, &context_block
     else
-#       warn <<EOM
-# --------------------------------------------------------------------------------------------------------------------------
-# AWS_TEST_DRIVER not set ... cannot run AWS test.  Set AWS_TEST_DRIVER=aws or aws:profile:region to run tests that hit AWS.
-# --------------------------------------------------------------------------------------------------------------------------
-# EOM
       skip "AWS_TEST_DRIVER not set ... cannot run AWS tests.  Set AWS_TEST_DRIVER=aws or aws:profile:region to run tests that hit AWS." do
         context description, *tags, &context_block
       end

--- a/spec/aws_support/matchers/have_aws_object_tags.rb
+++ b/spec/aws_support/matchers/have_aws_object_tags.rb
@@ -27,7 +27,7 @@ module AWSSupport
         differences = []
 
         # Check for object existence and properties
-        resource = resource_class.new(name, nil)
+        resource = resource_class.new(name, recipe.client.run_context)
         resource.driver example.driver
         resource.managed_entry_store Chef::Provisioning.chef_managed_entry_store
         @aws_object = resource.aws_object

--- a/spec/integration/aws_network_interface_spec.rb
+++ b/spec/integration/aws_network_interface_spec.rb
@@ -4,19 +4,18 @@ describe "AwsNetworkInterface" do
   when_the_chef_12_server "exists", organization: 'foo', server_scope: :context do
     with_aws "when connected to AWS" do
 
-      context "setting up public VPC", :super_slow do
+      context "setting up public VPC" do
 
-        # Putting this in its own context so it doesn't slow down other tests
         setup_public_vpc
 
-        it "creates an aws_network_interface resource with maximum attributes" do
+        it "creates an aws_network_interface resource with maximum attributes", :super_slow do
           expect_recipe {
             machine "test_machine" do
               machine_options bootstrap_options: {
                 subnet_id: 'test_public_subnet',
                 security_group_ids: ['test_security_group']
               }
-              action :allocate
+              action :ready
             end
 
             aws_network_interface 'test_network_interface' do


### PR DESCRIPTION
Chef 12.5.0 defines `Chef::NOT_PASSED` and chef-provisioning-aws was also defining this.  The double defining was causing issues with param validation.  There were also features (like `coerce` and `lazy_default`) being added to chef which are no longer required in 12.5

\cc @jkeiser @randomcamel 