### PR TITLE
Latest tagging refactors depend on chef-provisioning 1.4, updating the gemspec to reflect this

### DIFF
--- a/chef-provisioning-aws.gemspec
+++ b/chef-provisioning-aws.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.email = 'jewart@getchef.com'
   s.homepage = 'https://github.com/opscode/chef-provisioning-aws'
 
-  s.add_dependency 'chef-provisioning', '~> 1.3'
+  s.add_dependency 'chef-provisioning', '~> 1.4'
   s.add_dependency 'aws-sdk-v1', '>= 1.59.0'
   s.add_dependency 'aws-sdk', '~> 2.1'
   s.add_dependency 'retryable', '~> 2.0.1'


### PR DESCRIPTION
\cc @Jkeiser @randomcamel 