### PR TITLE
Making machine bootstrap_options backwards compatible to the V1 API

### DIFF
--- a/lib/chef/resource/aws_network_interface.rb
+++ b/lib/chef/resource/aws_network_interface.rb
@@ -5,7 +5,7 @@ require 'chef/resource/aws_eip_address'
 class Chef::Resource::AwsNetworkInterface < Chef::Provisioning::AWSDriver::AWSResourceWithEntry
   include Chef::Provisioning::AWSDriver::AWSTaggable
 
-  aws_sdk_type AWS::EC2::NetworkInterface
+  aws_sdk_type AWS::EC2::NetworkInterface, option_names: []
 
   attribute :name,                   kind_of: String, name_attribute: true
 

--- a/lib/chef/resource/aws_subnet.rb
+++ b/lib/chef/resource/aws_subnet.rb
@@ -16,7 +16,7 @@ require 'chef/provisioning/aws_driver/aws_resource_with_entry'
 class Chef::Resource::AwsSubnet < Chef::Provisioning::AWSDriver::AWSResourceWithEntry
   include Chef::Provisioning::AWSDriver::AWSTaggable
 
-  aws_sdk_type AWS::EC2::Subnet
+  aws_sdk_type AWS::EC2::Subnet, :id => :id
 
   require 'chef/resource/aws_vpc'
   require 'chef/resource/aws_network_acl'


### PR DESCRIPTION
Fixes https://github.com/chef/chef-provisioning-aws/issues/338
Fixes https://github.com/chef/chef-provisioning-aws/issues/322

\cc @randomcamel @jkeiser @tonyflint @cwebberOps 