### PR TITLE
[WIP] Working across different regions in a single recipe fails

### DIFF
--- a/spec/integration/aws_vpc_spec.rb
+++ b/spec/integration/aws_vpc_spec.rb
@@ -194,5 +194,25 @@ describe Chef::Resource::AwsVpc do
         end
       end
     end
+
+    with_aws "with no other objects" do
+      context "When operating in different regions" do
+        let(:regions) { %w(us-west-1 us-west-2) }
+
+        it "creates both VPCs" do
+          expect_recipe {
+            regions.each_with_index do |region, idx|
+              with_driver "aws::#{region}" do
+                aws_vpc "test_vpc_#{idx}" do
+                  cidr_block "10.0.#{idx}.0/24"
+                end
+              end
+            end
+          }.to create_an_aws_vpc("test_vpc_0"
+          ).and create_an_aws_vpc("test_vpc_1"
+          ).and be_idempotent
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR is not yet ready for merge, but the one commit here so far does demonstrate, I think, the underlying issue I am hitting.

Background: I'm trying to write a recipe that will connect a central VPN router to a series of satellite VPN routers, to that end my recipe looks approximately like:

```
label = "my_env"
node[:cluster][:satellite_regions].each do |region|
  with_driver "aws::#{region}" do
    cidr          = node[:cluster][:region_settings][region][:cidr]

    aws_vpc "#{label}-#{region}" do
      cidr_block            cidr
      internet_gateway      true
      enable_dns_support    true
      enable_dns_hostnames  true
    end

    aws_route_table "#{label}-#{region}-public-routes" do
      vpc "#{label}-#{region}"
    end
    
    machine "#{label}-#{region}-vpn01"
  end
end
```
And in my attributes file I have:

```
default[:cluster][:satellite_regions] = %w(us-east-1 eu-west-1)
default[:cluster][:region_settings]["us-east-1"][:cidr] = "10.0.0.0/24"
default[:cluster][:region_settings]["eu-west-1"][:cidr] = "10.0.1.0/24"
```

When converging, I was surprised to get an `AWS::EC2::Errors::InvalidVpcID::NotFound` exception referencing the *aws_route_table*(!) line.  The VPC clearly existed in the AWS console, so after some hunting, my conclusion was that either the wrong driver was being referenced or the correct driver was referencing the wrong region.

Adjusting my attributes to *only* use a single satellite region was a successful workaround.

While digging, I noticed [this call](https://github.com/chef/chef-provisioning-aws/blob/master/lib/chef/provisioning/aws_driver/driver.rb#L100) updates the config on the top level `::Aws` object, which seems like it would not be idempotent.  However I am not certain that this is the source of the problem.