### PR TITLE
Polishing touches for Route 53

### DIFF
--- a/docs/examples/route53.rb
+++ b/docs/examples/route53.rb
@@ -7,6 +7,9 @@ with_driver 'aws::us-east-1'
 # results, we prevent domain names from ending with a dot.
 aws_route53_hosted_zone "feegle.com."
 
+# a corollary to this is that chef-provisioning-aws does not support having two AWS HostedZones with the same
+# zone name, even though AWS itself does support this.
+
 # create a Route 53 Hosted Zone (which AWS will normalize to "feegle.com.").
 aws_route53_hosted_zone "feegle.com"
 
@@ -34,7 +37,7 @@ end
 aws_route53_hosted_zone "feegle.com" do
   record_sets {
     # the resource name can serve as the RR name.
-    aws_route53_record_set "tiffany.feegle.com" do
+    aws_route53_record_set "tiffany" do
       type "CNAME"
       ttl 1800
       resource_records ["a-different-host"]    # always an array of strings.
@@ -50,13 +53,30 @@ aws_route53_hosted_zone "feegle.com" do
         "192.168.10.89"
       ]
     end
+
+    # the RecordSet inherits the zone name, but you can specify it if you like.
+    aws_route53_record_set "tiffany.feegle.com" do
+      type "CNAME"
+      ttl 1800
+      resource_records ["a-different-host"]
+    end
+
+    # however, this is an error, since the domain here doesn't match the parent HostedZone.
+    aws_route53_record_set "tiffany.not-feegle.com" do
+      type "CNAME"
+      ttl 1800
+      resource_records ["a-different-host"]
+    end
   }
 end
 
 # some RR types have restrictions on the resource_records values:
+#
 #  MX:    "<integer priority> <mail server hostname>"
 #  SRV:   "<integer priority> <integer weight> <integer port> <server hostname>"
 #  CNAME: may only have a single value.
+#
+# chef-provisioning-aws does some validation for these, but we let AWS handle much of it.
 
 # delete an individual RecordSet. the values must be the same as those currently in Route 53, or else an AWS
 # error will bubble up.
@@ -75,4 +95,24 @@ end
 # calling :destroy on a zone will unconditionally wipe all of its RecordSets.
 aws_route53_hosted_zone "feegle.com" do
   action :destroy
+end
+
+# Compressing Recipes
+# you can set defaults for a zone that will be inherited (or overridden) by RecordSets.
+# currently supported defaultable attributes are :ttl and :type.
+aws_route53_hosted_zone "feegle.com" do
+  defaults ttl: 1800, type: "CNAME"
+
+  record_sets {
+    # type CNAME, TTL 1800.
+    aws_route53_record_set "host1" do
+      resource_records ["a-different-host"]
+    end
+
+    # type A, TTL 1800.
+    aws_route53_record_set "host2" do
+      type "A"
+      resource_records ["8.8.8.8"]
+    end
+  }
 end

--- a/lib/chef/resource/aws_route53_record_set.rb
+++ b/lib/chef/resource/aws_route53_record_set.rb
@@ -1,3 +1,20 @@
+#
+# Copyright:: Copyright (c) 2015 Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 class Aws::Route53::Types::ResourceRecordSet
   # removing AWS's trailing dots may not be the best thing, but otherwise our job gets much harder.
   def aws_key
@@ -24,22 +41,32 @@ class Chef::Resource::AwsRoute53RecordSet < Chef::Provisioning::AWSDriver::Super
   resource_name :aws_route53_record_set
   attribute :aws_route53_zone_id, kind_of: String, required: true
 
-  # if you add the trailing dot, AWS returns "FATAL problem: DomainLabelEmpty encountered," so we'll stop that
-  # ourselves.
-  attribute :rr_name, required: true, callbacks: { "cannot end with a dot" => lambda { |n| n !~ /\.$/ }}
+  attribute :rr_name, required: true
+
   attribute :type, equal_to: %w(SOA A TXT NS CNAME MX PTR SRV SPF AAAA), required: true
+
   attribute :ttl, kind_of: Fixnum, required: true
 
-  attribute :resource_records, kind_of: Array, required: true, is: lambda { |rr_list| validate_rr_type(type, rr_list) }
+  attribute :resource_records, kind_of: Array, required: true
+
+  # this gets set internally and is not intended for DSL use in recipes.
+  attribute :aws_route53_zone_name, kind_of: String, required: true,
+                                    is: lambda { |zone_name| validate_zone_name!(rr_name, zone_name) }
+
+  attribute :aws_route53_hosted_zone, required: true
 
   def initialize(name, *args)
     self.rr_name(name) unless @rr_name
     super(name, *args)
   end
 
-  def validate_rr_type(type, rr_list)
+  def validate_rr_type!(type, rr_list)
     case type
     # we'll check for integers, but leave the user responsible for valid DNS names.
+    when "A"
+      rr_list.all? { |v| v =~ /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/ } ||
+          raise(::Chef::Exceptions::ValidationFailed,
+                "A records are of the form '141.2.25.3'")
     when "MX"
       rr_list.all? { |v| v =~ /^\d+\s+[^ ]+/} ||
           raise(::Chef::Exceptions::ValidationFailed,
@@ -53,25 +80,43 @@ class Chef::Resource::AwsRoute53RecordSet < Chef::Provisioning::AWSDriver::Super
                 raise(::Chef::Exceptions::ValidationFailed,
                       "CNAME records may only have a single value (a hostname).")
 
-    when "SOA", "A", "TXT", "NS", "PTR", "AAAA"
+    when "TXT", "PTR", "AAAA", "SPF"
       true
     else
-      raise ArgumentError, "Argument '#{type}' must be one of #{%w(SOA A TXT NS CNAME MX PTR SPF AAAA)}"
+      raise ArgumentError, "Argument '#{type}' must be one of #{%w(A MX SRV CNAME TXT PTR AAAA SPF)}"
     end
+  end
+
+  def validate_zone_name!(rr_name, zone_name)
+    if rr_name.end_with?('.') && rr_name !~ /#{zone_name}\.$/
+      raise(::Chef::Exceptions::ValidationFailed, "RecordSet name #{rr_name} does not match parent HostedZone name #{zone_name}.")
+    end
+    true
   end
 
   # because these resources can't actually converge themselves, we have to trigger the validations.
   def validate!
-    [:rr_name, :type, :ttl, :resource_records].each { |f| self.send(f) }
+    [:rr_name, :type, :ttl, :resource_records, :aws_route53_zone_name].each { |f| self.send(f) }
+
+    # this was in an :is validator, but didn't play well with inheriting default values.
+    validate_rr_type!(type, resource_records)
   end
 
   def aws_key
-    "#{rr_name}"
+    "#{fqdn}"
+  end
+
+  def fqdn
+    if rr_name !~ /#{aws_route53_zone_name}\.?$/
+      "#{rr_name}.#{aws_route53_zone_name}"
+    else
+      rr_name
+    end
   end
 
   def to_aws_struct
     {
-      name: rr_name,
+      name: fqdn,
       type: type,
       ttl: ttl,
       resource_records: resource_records.map { |rr| { value: rr } },

--- a/spec/integration/aws_route53_hosted_zone_spec.rb
+++ b/spec/integration/aws_route53_hosted_zone_spec.rb
@@ -130,6 +130,36 @@ describe Chef::Resource::AwsRoute53HostedZone do
             # the empty {} acts as a wildcard, and all zones have SOA and NS records we want to skip.
           end
 
+          it "creates a hosted zone with a RecordSet with an RR name with a trailing dot" do
+            expect_recipe {
+              aws_route53_hosted_zone "feegle.com" do
+                record_sets {
+                  aws_route53_record_set "some-host.feegle.com." do
+                    type "CNAME"
+                    ttl 3600
+                    resource_records ["some-other-host"]
+                  end
+                }
+              end
+            }.to create_an_aws_route53_hosted_zone("feegle.com",
+                                                   resource_record_sets: [{}, {}, sdk_cname_rr]).and be_idempotent
+          end
+
+          # AWS's error for this is "FATAL problem: DomainLabelEmpty encountered", so we help the user out.
+          it "crashes with a RecordSet with a mismatched zone name with a trailing dot" do
+            expect_converge {
+              aws_route53_hosted_zone "feegle.com" do
+                record_sets {
+                  aws_route53_record_set "some-host.wrong-zone.com." do
+                    type "CNAME"
+                    ttl 3600
+                    resource_records ["some-other-host"]
+                  end
+                }
+              end
+            }.to raise_error(Chef::Exceptions::ValidationFailed, /RecordSet name.*does not match parent/)
+          end
+
           it "creates and updates a RecordSet" do
             expected_rr = sdk_cname_rr.merge({ ttl: 1800 })
 
@@ -137,7 +167,7 @@ describe Chef::Resource::AwsRoute53HostedZone do
               aws_route53_hosted_zone "feegle.com" do
                 record_sets {
                   aws_route53_record_set "some-hostname CNAME" do
-                    rr_name "some-host.feegle.com"
+                    rr_name "some-host"
                     type "CNAME"
                     ttl 3600
                     resource_records ["some-other-host"]
@@ -148,7 +178,7 @@ describe Chef::Resource::AwsRoute53HostedZone do
               aws_route53_hosted_zone "feegle.com" do
                 record_sets {
                   aws_route53_record_set "some-hostname CNAME" do
-                    rr_name "some-host.feegle.com"
+                    rr_name "some-host"
                     type "CNAME"
                     ttl 1800
                     resource_records ["some-other-host"]
@@ -163,8 +193,7 @@ describe Chef::Resource::AwsRoute53HostedZone do
             expect_recipe {
               aws_route53_hosted_zone "feegle.com" do
                 record_sets {
-                  aws_route53_record_set "some-hostname CNAME" do
-                    rr_name "some-api-host.feegle.com"
+                  aws_route53_record_set "some-api-host" do
                     type "CNAME"
                     ttl 3600
                     resource_records ["some-other-host"]
@@ -174,9 +203,8 @@ describe Chef::Resource::AwsRoute53HostedZone do
 
               aws_route53_hosted_zone "feegle.com" do
                 record_sets {
-                  aws_route53_record_set "some-hostname CNAME" do
+                  aws_route53_record_set "some-api-host" do
                     action :destroy
-                    rr_name "some-api-host.feegle.com"
                     type "CNAME"
                     ttl 3600
                     resource_records ["some-other-host"]
@@ -185,6 +213,21 @@ describe Chef::Resource::AwsRoute53HostedZone do
               end
             }.to create_an_aws_route53_hosted_zone("feegle.com",
                                                    resource_record_sets: [{}, {}]).and be_idempotent
+          end
+
+          it "automatically uses the parent zone name in the RecordSet name" do
+            expect_recipe {
+              aws_route53_hosted_zone "feegle.com" do
+                record_sets {
+                  aws_route53_record_set "some-host" do
+                    type "CNAME"
+                    ttl 3600
+                    resource_records ["some-other-host"]
+                  end
+                }
+              end
+            }.to create_an_aws_route53_hosted_zone("feegle.com",
+                                                   resource_record_sets: [{}, {}, sdk_cname_rr]).and be_idempotent
           end
 
           it "raises the AWS exception when trying to delete a record using mismatched values" do
@@ -222,7 +265,7 @@ describe Chef::Resource::AwsRoute53HostedZone do
             expect_recipe {
               aws_route53_hosted_zone "feegle.com" do
                 record_sets {
-                  aws_route53_record_set "some-host.feegle.com" do
+                  aws_route53_record_set "some-host" do
                     type "CNAME"
                     ttl 3600
                     resource_records ["some-other-host"]
@@ -233,20 +276,61 @@ describe Chef::Resource::AwsRoute53HostedZone do
                                                    resource_record_sets: [{}, {}, sdk_cname_rr]).and be_idempotent
           end
 
-          it "applies the :rr_name validations to :name" do
-            @zone_to_delete = "feegle.com"
+          context "inheriting default property values" do
+            it "provides zone defaults for RecordSet values" do
+              expected_a = {
+                name: "another-host.feegle.com.",
+                type: "A",
+                ttl: 3600,
+                resource_records: [{value: "8.8.8.8"}]
+              }
+              expect_recipe {
+                aws_route53_hosted_zone "feegle.com" do
+                  defaults ttl: 3600, type: "CNAME"
+                  record_sets {
+                    aws_route53_record_set "some-host" do
+                      resource_records ["some-other-host"]
+                    end
+                    aws_route53_record_set "another-host" do
+                      type "A"
+                      resource_records ["8.8.8.8"]
+                    end
+                  }
+                end
+              }.to create_an_aws_route53_hosted_zone("feegle.com",
+                                                     resource_record_sets: [{}, {},
+                                                      expected_a, sdk_cname_rr]).and be_idempotent
+            end
 
-            expect_converge {
-              aws_route53_hosted_zone "feegle.com" do
-                record_sets {
-                  aws_route53_record_set "some-host.feegle.com." do
-                    type "CNAME"
-                    ttl 3600
-                    resource_records ["some-other-host"]
-                  end
-                }
-              end
-            }.to raise_error(Chef::Exceptions::ValidationFailed, /Option rr_name.*cannot end with a dot/)
+            it "only provides defaults for certain properties" do
+              expect_converge {
+                aws_route53_hosted_zone "feegle.com" do
+                  defaults invalid_default: 42
+                  record_sets {
+                    aws_route53_record_set "some-host" do
+                      resource_records ["some-other-host"]
+                    end
+                    aws_route53_record_set "another-host" do
+                      type "A"
+                      resource_records ["8.8.8.8"]
+                    end
+                  }
+                end
+              }.to raise_error(Chef::Exceptions::ValidationFailed, /'defaults' keys may be any of/)
+            end
+
+            it "checks for requiredness" do
+              expect_converge {
+                aws_route53_hosted_zone "feegle.com" do
+                  defaults ttl: 3600
+                  record_sets {
+                    aws_route53_record_set "some-host" do
+                      resource_records ["some-other-host"]
+                    end
+                  }
+                end
+              }.to raise_error(Chef::Exceptions::ValidationFailed, /required/i)
+            end
           end
 
           context "individual RR types" do
@@ -255,7 +339,7 @@ describe Chef::Resource::AwsRoute53HostedZone do
                 name: "cname-host.feegle.com.",
                 type: "CNAME",
                 ttl: 1800,
-                resource_records: [{ value: "141.222.1.1"}, { value: "8.8.8.8" }],
+                resource_records: [{ value: "8.8.8.8" }],
               },
               a: {
                 name: "a-host.feegle.com.",
@@ -291,11 +375,38 @@ describe Chef::Resource::AwsRoute53HostedZone do
               },
             }}
 
-            it "handles an A record" do
+            it "handles CNAME records" do
               expect_recipe {
                 aws_route53_hosted_zone "feegle.com" do
                   record_sets {
-                    aws_route53_record_set "A-host.feegle.com" do
+                    aws_route53_record_set "CNAME-host" do
+                      type "CNAME"
+                      ttl 1800
+                      resource_records ["8.8.8.8"]
+                    end
+                  }
+                end
+              }.to create_an_aws_route53_hosted_zone("feegle.com",
+                                                     resource_record_sets: [ {}, {}, expected[:cname] ]).and be_idempotent
+
+              expect_converge {
+                aws_route53_hosted_zone "feegle.com" do
+                  record_sets {
+                    aws_route53_record_set "CNAME-host" do
+                      type "CNAME"
+                      ttl 1800
+                      resource_records ["141.222.1.1", "8.8.8.8"]
+                    end
+                  }
+                end
+              }.to raise_error(Chef::Exceptions::ValidationFailed, /CNAME records.*have a single value/)
+            end
+
+            it "handles A records" do
+              expect_recipe {
+                aws_route53_hosted_zone "feegle.com" do
+                  record_sets {
+                    aws_route53_record_set "A-host" do
                       type "A"
                       ttl 1800
                       resource_records ["141.222.1.1", "8.8.8.8"]
@@ -304,12 +415,26 @@ describe Chef::Resource::AwsRoute53HostedZone do
                 end
               }.to create_an_aws_route53_hosted_zone("feegle.com",
                                                      resource_record_sets: [ {}, {}, expected[:a] ]).and be_idempotent
+
+              expect_converge {
+                aws_route53_hosted_zone "feegle.com" do
+                  record_sets {
+                    aws_route53_record_set "A-host" do
+                      type "A"
+                      ttl 1800
+                      resource_records ["hostnames-dont-go-here.com", "8.8.8.8"]
+                    end
+                  }
+                end
+              }.to raise_error(Chef::Exceptions::ValidationFailed, /A records are of the form/)
             end
-            it "handles an AAAA record" do
+
+            # we don't validate IPv6 addresses, because they are complex.
+            it "handles AAAA records" do
               expect_recipe {
                 aws_route53_hosted_zone "feegle.com" do
                   record_sets {
-                    aws_route53_record_set "AAAA-host.feegle.com" do
+                    aws_route53_record_set "AAAA-host" do
                       type "AAAA"
                       ttl 1800
                       resource_records ["2607:f8b0:4010:801::1001", "2607:f8b9:4010:801::1001"]
@@ -319,11 +444,12 @@ describe Chef::Resource::AwsRoute53HostedZone do
               }.to create_an_aws_route53_hosted_zone("feegle.com",
                                                      resource_record_sets: [ {}, {}, expected[:aaaa] ]).and be_idempotent
             end
-            it "handles an MX record" do
+
+            it "handles MX records" do
               expect_recipe {
                 aws_route53_hosted_zone "feegle.com" do
                   record_sets {
-                    aws_route53_record_set "MX-host.feegle.com" do
+                    aws_route53_record_set "MX-host" do
                       type "MX"
                       ttl 1800
                       resource_records ["10 mail1.example.com", "15 mail2.example.com."]
@@ -332,12 +458,26 @@ describe Chef::Resource::AwsRoute53HostedZone do
                 end
               }.to create_an_aws_route53_hosted_zone("feegle.com",
                                                      resource_record_sets: [ {}, {}, expected[:mx] ]).and be_idempotent
+              expect_converge {
+                aws_route53_hosted_zone "feegle.com" do
+                  record_sets {
+                    aws_route53_record_set "MX-host" do
+                      type "MX"
+                      ttl 1800
+                      resource_records ["10mail1.example.com", "mail2.example.com."]
+                    end
+                  }
+                end
+              }.to raise_error(Chef::Exceptions::ValidationFailed, /MX records must have a priority and mail server/)
             end
-            it "handles an TXT record" do
+
+            # we don't validate TXT values:
+            # http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/ResourceRecordTypes.html#TXTFormat
+            it "handles TXT records" do
               expect_recipe {
                 aws_route53_hosted_zone "feegle.com" do
                   record_sets {
-                    aws_route53_record_set "TXT-host.feegle.com" do
+                    aws_route53_record_set "TXT-host" do
                       type "TXT"
                       ttl 300
                       resource_records %w["Very\ Important\ Data" "Even\ More\ Important\ Data"]
@@ -347,11 +487,12 @@ describe Chef::Resource::AwsRoute53HostedZone do
               }.to create_an_aws_route53_hosted_zone("feegle.com",
                                                      resource_record_sets: [ {}, {}, expected[:txt] ]).and be_idempotent
             end
-            it "handles an SRV record" do
+
+            it "handles SRV records" do
               expect_recipe {
                 aws_route53_hosted_zone "feegle.com" do
                   record_sets {
-                    aws_route53_record_set "SRV-host.feegle.com" do
+                    aws_route53_record_set "SRV-host" do
                       type "SRV"
                       ttl 300
                       resource_records ["10 50 8889 chef-server.example.com", "20 70 80 narf.net"]
@@ -360,11 +501,21 @@ describe Chef::Resource::AwsRoute53HostedZone do
                 end
               }.to create_an_aws_route53_hosted_zone("feegle.com",
                                                      resource_record_sets: [ {}, {}, expected[:srv] ]).and be_idempotent
+
+              expect_converge {
+                aws_route53_hosted_zone "feegle.com" do
+                  record_sets {
+                    aws_route53_record_set "SRV-host" do
+                      type "SRV"
+                      ttl 300
+                      resource_records ["1050 8889 chef-server.example.com", "narf.net"]
+                    end
+                  }
+                end
+              }.to raise_error(Chef::Exceptions::ValidationFailed, /SRV.*priority, weight, port, and hostname/)
             end
           end  # end RR types
         end
-
-        it "handles multiple actions gracefully"
       end
     end
   end

--- a/spec/unit/chef/provisioning/aws_driver/route53_spec.rb
+++ b/spec/unit/chef/provisioning/aws_driver/route53_spec.rb
@@ -8,12 +8,17 @@ end
 describe Chef::Resource::AwsRoute53RecordSet do
 
   let(:resource_name) { "test_resource" }
-  let(:resource) { Chef::Resource::AwsRoute53RecordSet.new(resource_name) }
+  let(:zone_name) { "blerf.net" }
+  let(:resource) {
+    r = Chef::Resource::AwsRoute53RecordSet.new(resource_name)
+    r.aws_route53_zone_name(zone_name)
+    r
+  }
 
   it "returns the correct RecordSet unique key" do
-    expect(resource.aws_key).to eq(resource_name)
+    expect(resource.aws_key).to eq("#{resource_name}.#{zone_name}")
     resource.rr_name("new-name")
-    expect(resource.aws_key).to eq("new-name")
+    expect(resource.aws_key).to eq("new-name.#{zone_name}")
   end
 
   it "returns the correct AWS change struct" do
@@ -22,7 +27,7 @@ describe Chef::Resource::AwsRoute53RecordSet do
     resource.type("A")
     resource.resource_records(["141.222.1.1", "8.8.8.8"])
 
-    expect(resource.to_aws_struct).to eq({ :name=>"foo",
+    expect(resource.to_aws_struct).to eq({ :name=>"foo.blerf.net",
                                            :type=>"A",
                                            :ttl=>900, 
                                            :resource_records=>[{:value=>"141.222.1.1"}, {:value=>"8.8.8.8"}]
@@ -32,37 +37,66 @@ describe Chef::Resource::AwsRoute53RecordSet do
   context "#validate_rr_type" do
     it "validates MX values" do
       correct = 2.times.map { [rand(10000), rand(36**40).to_s(36)].join(" ") }
-      expect(resource.validate_rr_type("MX", correct)).to be_truthy
+      expect(resource.validate_rr_type!("MX", correct)).to be_truthy
 
       incorrect = ["string content doesn't matter without a number"]
-      expect { resource.validate_rr_type("MX", incorrect) }.to raise_error(Chef::Exceptions::ValidationFailed,
-                                                                           /MX.*priority and mail server/)
+      expect { resource.validate_rr_type!("MX", incorrect) }.to raise_error(Chef::Exceptions::ValidationFailed,
+                                                                            /MX.*priority and mail server/)
     end
 
     it "validates SRV values" do
       correct = 2.times.map { [rand(10000), rand(10000), rand(10000), rand(36**40).to_s(36)].join(" ") }
-      expect(resource.validate_rr_type("MX", correct)).to be_truthy
+      expect(resource.validate_rr_type!("MX", correct)).to be_truthy
 
       incorrect = ["string content doesn't matter without a number"]
-      expect { resource.validate_rr_type("SRV", incorrect) }.to raise_error(Chef::Exceptions::ValidationFailed,
-                                                                            /SRV.*priority, weight, port, and hostname/)
+      expect { resource.validate_rr_type!("SRV", incorrect) }.to raise_error(Chef::Exceptions::ValidationFailed,
+                                                                             /SRV.*priority, weight, port, and hostname/)
     end
 
     it "validates CNAME values" do
       correct = ["foo"]
-      expect(resource.validate_rr_type("CNAME", correct)).to be_truthy
+      expect(resource.validate_rr_type!("CNAME", correct)).to be_truthy
 
       incorrect = ["foo1", "foo2"]
-      expect { resource.validate_rr_type("CNAME", incorrect) }.to raise_error(Chef::Exceptions::ValidationFailed,
-                                                                            /CNAME records may only have a single value/)
+      expect { resource.validate_rr_type!("CNAME", incorrect) }.to raise_error(Chef::Exceptions::ValidationFailed,
+                                                                               /CNAME records may only have a single value/)
     end
 
-    it "only accepts the remaining RR types" do
-      %w(SOA A TXT NS PTR AAAA).each do |type|
-        expect(resource.validate_rr_type(type, "We're not validating anything on these types.")).to be_truthy
+    it "validates A values" do
+      correct = ["141.222.1.1", "8.8.8.8"]
+      expect(resource.validate_rr_type!("A", correct)).to be_truthy
+
+      incorrect = ["141.222.1.500", "8.8.8.8x"]
+      expect { resource.validate_rr_type!("A", incorrect) }.to raise_error(Chef::Exceptions::ValidationFailed,
+                                                                           /A records are of the form/)
+    end
+
+    it "quietly accepts the remaining RR types" do
+      %w(TXT PTR AAAA SPF).each do |type|
+        expect(resource.validate_rr_type!(type, "We're not validating anything on type '#{type}'.")).to be_truthy
       end
 
-      expect { resource.validate_rr_type("not a valid RR type", nil) }.to raise_error(ArgumentError)
+      ["SOA", "NS", nil].each do |invalid_type|
+        expect { resource.validate_rr_type!("not a valid RR type", invalid_type) }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  context "#fqdn" do
+    it "generates correct FQDNs" do
+      zone_name = "23skidoo.com"
+      hostname = "fnord"
+
+      resource.aws_route53_zone_name(zone_name)
+      expect(resource.fqdn).to eq("#{resource_name}.#{zone_name}")
+
+      fq_resource = Chef::Resource::AwsRoute53RecordSet.new("#{hostname}.#{zone_name}")
+      fq_resource.aws_route53_zone_name(zone_name)
+      expect(fq_resource.fqdn).to eq("#{hostname}.#{zone_name}")
+
+      fq_resource = Chef::Resource::AwsRoute53RecordSet.new("#{hostname}.#{zone_name}.")
+      fq_resource.aws_route53_zone_name(zone_name)
+      expect(fq_resource.fqdn).to eq("#{hostname}.#{zone_name}.")
     end
   end
 end


### PR DESCRIPTION
- [x] RecordSet names inherit the zone name automatically.
- [x] Variables from the declared scope are accessible inside RecordSets.
- [x] Parent zone has a `defaults` hash of values inherited by RecordSets.
