### PR TITLE
Fix deleting of AMIs, fixes #311

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -39,7 +39,7 @@ end
 
 desc "travis specific task - runs CI integration tests (regular and super_slow in parallel) and sets up travis specific ENV variables"
 task :travis, [:sub_task] do |t, args|
-  pattern = "load_balancer_spec.rb" # This is a comma seperated list
+  pattern = "load_balancer_spec.rb,machine_image_spec.rb" # This is a comma seperated list
   pattern = pattern.split(",").map {|p| "spec/integration/**/*#{p}"}.join(",")
   Rake::Task[args[:sub_task]].invoke(pattern)
 end

--- a/lib/chef/provider/aws_image.rb
+++ b/lib/chef/provider/aws_image.rb
@@ -29,7 +29,7 @@ class Chef::Provider::AwsImage < Chef::Provisioning::AWSDriver::AWSProvider
       # destroyed - we just need to make sure that has completed successfully
       instance = new_resource.driver.ec2.instances[instance_id]
       converge_by "waiting until instance #{instance.id} is :terminated" do
-        wait_for_status(instance, :terminated, [AWS::EC2::Errors::InvalidInstanceID::NotFound])
+        wait_for_status(instance, :terminated, [AWS::EC2::Errors::InvalidInstanceID::NotFound, AWS::Core::Resource::NotFound])
       end
     end
   end

--- a/spec/integration/machine_image_spec.rb
+++ b/spec/integration/machine_image_spec.rb
@@ -26,7 +26,7 @@ describe Chef::Resource::MachineImage do
         ).and be_idempotent
       end
 
-      describe 'action :destroy' do
+      describe 'action :destroy', :super_slow do
         with_converge {
           machine_image 'test_machine_image' do
             machine_options bootstrap_options: {
@@ -37,7 +37,7 @@ describe Chef::Resource::MachineImage do
           end
         }
 
-        it "deletes the image" do
+        it "destroys the image" do
           r = recipe {
             machine_image "test_machine_image" do
               action :destroy
@@ -47,9 +47,9 @@ describe Chef::Resource::MachineImage do
           ).and be_idempotent
         end
 
-        it "deletes the image if instance is gone long time ago" do
+        it "destroys the image if instance is gone long time ago" do
           image = driver.ec2_resource.images({filters: [ { name: "name", values: ["test_machine_image"] }]}).first
-          image.create_tags(tags: [{key: "from-instance", value: "i-4e5b71e8"}])
+          image.create_tags(tags: [{key: "from-instance", value: "i-12345678"}])
 
           r = recipe {
             machine_image "test_machine_image" do

--- a/spec/integration/machine_image_spec.rb
+++ b/spec/integration/machine_image_spec.rb
@@ -25,6 +25,42 @@ describe Chef::Resource::MachineImage do
           name: 'test_machine_image'
         ).and be_idempotent
       end
+
+      describe 'action :destroy' do
+        with_converge {
+          machine_image 'test_machine_image' do
+            machine_options bootstrap_options: {
+              subnet_id: 'test_public_subnet',
+              key_name: 'test_key_pair',
+              instance_type: 'm3.medium'
+            }
+          end
+        }
+
+        it "deletes the image" do
+          r = recipe {
+            machine_image "test_machine_image" do
+              action :destroy
+            end
+          }
+          expect(r).to destroy_an_aws_image('test_machine_image'
+          ).and be_idempotent
+        end
+
+        it "deletes the image if instance is gone long time ago" do
+          image = driver.ec2_resource.images({filters: [ { name: "name", values: ["test_machine_image"] }]}).first
+          image.create_tags(tags: [{key: "from-instance", value: "i-4e5b71e8"}])
+
+          r = recipe {
+            machine_image "test_machine_image" do
+              action :destroy
+            end
+          }
+          expect(r).to destroy_an_aws_image('test_machine_image'
+          ).and be_idempotent
+        end
+      end
+
     end
 
     with_aws "Without a VPC" do


### PR DESCRIPTION
Previous implementation was checking against `AWS::EC2::Errors::InvalidInstanceID::NotFound` exception, which is listed as a valid exception in AWS docs. In reality, though, actual exception AWS returns is `AWS::Core::Resource::NotFound`. 

Previous implementation worked by accident, because if you create and then instantly delete an image, then instance is still around with terminated state, but if you try to create now and then delete in few hours, then  `AWS::Core::Resource::NotFound` will be returned and recipe will fail.

That the exact reason of this issue: https://github.com/chef/chef-provisioning-aws/issues/311 appearing. Now it's fixed.