### PR TITLE
fix a bug where an existing zone with a comment would explode if no comment was given

### DIFF
--- a/lib/chef/resource/aws_route53_hosted_zone.rb
+++ b/lib/chef/resource/aws_route53_hosted_zone.rb
@@ -36,7 +36,7 @@ class Chef::Resource::AwsRoute53HostedZone < Chef::Provisioning::AWSDriver::AWSR
   attribute :name, kind_of: String, callbacks: { "domain name cannot end with a dot" => lambda { |n| n !~ /\.$/ } }
 
   # The comment included in the CreateHostedZoneRequest element. String <= 256 characters.
-  attribute :comment, kind_of: String
+  attribute :comment, kind_of: String, default: ""
 
   # the resource name and the AWS ID have to be related here, since they're tightly coupled elsewhere.
   attribute :aws_route53_zone_id, kind_of: String, aws_id_attribute: true,

--- a/spec/integration/aws_route53_hosted_zone_spec.rb
+++ b/spec/integration/aws_route53_hosted_zone_spec.rb
@@ -64,6 +64,17 @@ describe Chef::Resource::AwsRoute53HostedZone do
             }.to create_an_aws_route53_hosted_zone(zone_name,
                                                    config: { comment: expected_comment }).and be_idempotent
           end
+
+          it "updates the zone comment when none is given" do
+            expect_recipe {
+              aws_route53_hosted_zone zone_name do
+                comment "Initial comment."
+              end
+              aws_route53_hosted_zone zone_name do
+              end
+            }.to create_an_aws_route53_hosted_zone(zone_name,
+                                                   config: { comment: nil }).and be_idempotent
+          end
         end
 
         context "RecordSets" do


### PR DESCRIPTION
Title pretty much says it all.  I had an existing zone (created by AWS's registrar) and when I tried to manage it with chef-provisioning-aws, things broke.

Side question - are there plans to support ALIAS records for R53?