### PR TITLE
fix aws_rds_subnet_group example

### DIFF
--- a/docs/examples/aws_rds_subnet_group.rb
+++ b/docs/examples/aws_rds_subnet_group.rb
@@ -19,7 +19,7 @@ end
 # availability zones to function, that is why two subnets are defined
 # in this example.
 aws_rds_subnet_group "db-subnet-group" do
-  db_subnet_group_description "some_description"
+  description "some_description"
   subnets ['subnet', subnet2.aws_object.id]
 end
 


### PR DESCRIPTION
example was using wrong attribute name, corrected according to attribute defined in 
https://github.com/chef/chef-provisioning-aws/blob/master/lib/chef/resource/aws_rds_subnet_group.rb#L11