### PR TITLE
Adds actions to add/del routing entries from aws_route_table resource

### DIFF
--- a/lib/chef/resource/aws_route_table.rb
+++ b/lib/chef/resource/aws_route_table.rb
@@ -16,6 +16,8 @@ class Chef::Resource::AwsRouteTable < Chef::Provisioning::AWSDriver::AWSResource
   include Chef::Provisioning::AWSDriver::AWSTaggable
   aws_sdk_type ::Aws::EC2::RouteTable
 
+  actions :route_add, :route_del, :create, :destroy, :purge, :nothing
+
   require 'chef/resource/aws_vpc'
 
   #
@@ -70,6 +72,19 @@ class Chef::Resource::AwsRouteTable < Chef::Provisioning::AWSDriver::AWSResource
   # - Chef machine resource
   #
   attribute :routes, kind_of: Hash
+
+  #
+  # The route to add/delete for this routing table
+  #
+  # This attribute must be specified for the actions :route_add and :route_del.
+  # The Hash can include several entries to remove/add at a time. The format of the
+  # Hash entries is the same format for the routes attribute.
+  #
+  # ```ruby
+  # route '0.0.0.0/0' => :internet_gateway
+  # ```
+  #
+  attribute :route, kind_of: Hash
 
   #
   # Regex to ignore one or more route targets.

--- a/spec/integration/aws_route_table_spec.rb
+++ b/spec/integration/aws_route_table_spec.rb
@@ -84,6 +84,40 @@ describe Chef::Resource::AwsRouteTable do
             ]
           ).and be_idempotent
         end
+
+        it "adds a new routing table entry" do
+          expect_recipe {
+            aws_route_table 'test_route_table' do
+              vpc 'test_vpc'
+              route '2.0.0.0/8' => :internet_gateway
+              action :route_add
+            end
+
+          }.to update_an_aws_route_table('test_route_table',
+            routes: [
+              { destination_cidr_block: '2.0.0.0/8', gateway_id: test_vpc.aws_object.internet_gateway.id, state: "active" },
+              { destination_cidr_block: '10.0.0.0/16', gateway_id: 'local', state: "active" },
+              { destination_cidr_block: '0.0.0.0/0', gateway_id: test_vpc.aws_object.internet_gateway.id, state: "active" },
+            ]
+          ).and be_idempotent
+        end
+
+        it "deletes an existing routing table entry" do
+          expect_recipe {
+            aws_route_table 'test_route_table' do
+              vpc 'test_vpc'
+              route '1.0.0.0/8' => :internet_gateway
+              action :route_del
+            end
+
+          }.to update_an_aws_route_table('test_route_table',
+            routes: [
+              { destination_cidr_block: '2.0.0.0/8', gateway_id: test_vpc.aws_object.internet_gateway.id, state: "active" },
+              { destination_cidr_block: '10.0.0.0/16', gateway_id: 'local', state: "active" },          
+            ]
+          ).and be_idempotent
+        end
+
       end
 
       context "with machines", :super_slow do


### PR DESCRIPTION
When using actions :route_add and :route_del for an specified route_table
resorce, the routing entry defined in the 'route' attribute will be
added or deleted from the routing table, respectively.

This allows more fine grained control on the aws routing table objects.

example

``` ruby
aws_route_table 'test_route_table' do
  vpc 'test_vpc'
  routes '0.0.0.0/0' => :internet_gateway
end

aws_route_table 'test_route_table' do
  vpc 'test_vpc'
  route '2.0.0.0/8' => :internet_gateway
  action :route_add
end

aws_route_table 'test_route_table' do
  vpc 'test_vpc'
  route '2.0.0.0/8' => :internet_gateway
  action :route_del
end
```
