### PR TITLE
Fix warning in aws_key_pair

### DIFF
--- a/lib/chef/provider/aws_key_pair.rb
+++ b/lib/chef/provider/aws_key_pair.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'chef/provider/lwrp_base'
 require 'chef/provisioning/aws_driver/aws_provider'
 require 'aws-sdk-v1'
@@ -102,7 +103,7 @@ class Chef::Provider::AwsKeyPair < Chef::Provisioning::AWSDriver::AWSProvider
     private_key_path = new_private_key_path
     Cheffish.inline_resource(self, action) do
       private_key private_key_path do
-        public_key_path resource.public_key_path
+        public_key_path resource.public_key_path if resource.public_key_path
         if resource.private_key_options
           resource.private_key_options.each_pair do |key,value|
             send(key, value)

--- a/lib/chef/provider/aws_key_pair.rb
+++ b/lib/chef/provider/aws_key_pair.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 require 'chef/provider/lwrp_base'
 require 'chef/provisioning/aws_driver/aws_provider'
 require 'aws-sdk-v1'
@@ -45,8 +44,8 @@ class Chef::Provider::AwsKeyPair < Chef::Provisioning::AWSDriver::AWSProvider
       end
 
 
-      # “The nice thing about standards is that you have so many to
-      # choose from.” - Andrew S. Tanenbaum
+      # "The nice thing about standards is that you have so many to
+      # choose from." - Andrew S. Tanenbaum
       #
       # The AWS EC2 API uses a PKCS#1 MD5 fingerprint for keys that you
       # import into EC2, but a PKCS#8 SHA1 fingerprint for keys that you

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,3 +28,5 @@ end
 Chef::Config[:log_level] = :warn
 
 require 'cheffish/rspec/matchers'
+# Uncomment me to investigate deprecation warnings
+# Chef::Config.treat_deprecation_warnings_as_errors(true)


### PR DESCRIPTION
aws_key_pair can still emit many deprecation warnings because of underlying problems in Cheffish and chef-provisioning; but this solves 1 of them.
