### PR TITLE
set ssh_username from machine options

### DIFF
--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -1014,7 +1014,7 @@ EOD
 
     def create_ssh_transport(machine_spec, machine_options, instance)
       ssh_options = ssh_options_for(machine_spec, machine_options, instance)
-      username = machine_spec.reference['ssh_username'] || machine_options[:ssh_username] || default_ssh_username
+      username = machine_spec.reference['ssh_username'] || machine_options[:ssh_username] || machine_options[:machine_options][:ssh_username] || default_ssh_username
       if machine_options.has_key?(:ssh_username) && machine_options[:ssh_username] != machine_spec.reference['ssh_username']
         Chef::Log.warn("Server #{machine_spec.name} was created with SSH username #{machine_spec.reference['ssh_username']} and machine_options specifies username #{machine_options[:ssh_username]}.  Using #{machine_spec.reference['ssh_username']}.  Please edit the node and change the chef_provisioning.reference.ssh_username attribute if you want to change it.")
       end


### PR DESCRIPTION
my machines never become connectable because it's trying to connect at `ubuntu`
```
[6] pry(#<Chef::Provisioning::AWSDriver::Driver>)> machine_options['ssh_username']
=> nil
[11] pry(#<Chef::Provisioning::AWSDriver::Driver>)> machine_options[:machine_options][:ssh_username]
=> "admin"
```

```
    - been waiting 20/500 -- sleeping 10 seconds for bastion-us-east-1d (i-03f8eeb3 on aws::us-east-1) to become connectable ...[2015-12-16T13:50:08-07:00] INFO: Executing sudo pwd on ubuntu@DERP
[2015-12-16T13:50:08-07:00] DEBUG: Opening SSH connection to ubuntu@DERP with options {:timeout=>10, :auth_methods=>["publickey"], :keys_only=>true, :host_key_alias=>"i-03f8eeb3.AWS"}
[2015-12-16T13:50:09-07:00] DEBUG: ubuntu@DERP unavailable: SSH authentication error: #<Net::SSH::AuthenticationFailed: Authentication failed for user ubuntu@DERP>
```