### PR TITLE
Add a health check to the load balancer options example

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,14 @@ load_balancer "my_elb" do
           port: 443,
           ssl_certificate_id: "arn:aws:iam::360965486607:server-certificate/cloudfront/foreflight-2015-07-09"
       }
-    ]
+    ],
+    health_check: {
+      healthy_threshold: 2,
+      unhealthy_threshold: 4,
+      interval: 12,
+      timeout: 5,
+      target: 'HTTPS:443/_status'
+    }
   })
 ```
 


### PR DESCRIPTION
This adds an example of adding a health check to a load balancer in the `load_balancer_options` in the example in the docs as discussed in #420 