### PR TITLE
fix case where ssl_certificate_id changes after create fails with 'expected string value'

### DIFF
--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -338,8 +338,8 @@ module AWSDriver
               elsif ! server_certificate_eql?(listener.server_certificate,
                                               server_cert_from_spec(desired_listener))
                 # Server certificate is mutable - if no immutable changes required a full recreate, update cert
-                perform_action.call("    update server certificate from #{listener.server_certificate} to #{desired_listener[:server_certificate]}") do
-                  listener.server_certificate = desired_listener[:server_certificate]
+                perform_action.call("    update server certificate from #{listener.server_certificate} to #{server_cert_from_spec(desired_listener)}") do
+                  listener.server_certificate = server_cert_from_spec(desired_listener)
                 end
               end
 
@@ -354,7 +354,7 @@ module AWSDriver
             updates << "    set protocol to #{listener[:protocol].inspect}"
             updates << "    set instance port to #{listener[:instance_port].inspect}"
             updates << "    set instance protocol to #{listener[:instance_protocol].inspect}"
-            updates << "    set server certificate to #{listener[:server_certificate]}" if listener[:server_certificate]
+            updates << "    set server certificate to #{server_cert_from_spec(listener)}" if server_cert_from_spec(listener)
             perform_action.call(updates) do
               actual_elb.listeners.create(listener)
             end

--- a/spec/integration/load_balancer_spec.rb
+++ b/spec/integration/load_balancer_spec.rb
@@ -24,6 +24,11 @@ describe Chef::Resource::LoadBalancer do
         private_key private_key_string
       end
 
+      aws_server_certificate "load_balancer_cert_2" do
+        certificate_body cert_string
+        private_key private_key_string
+      end
+
       it "creates a load_balancer with the maximum attributes" do
         expect_recipe {
           load_balancer 'test-load-balancer' do
@@ -173,6 +178,13 @@ describe Chef::Resource::LoadBalancer do
                 :protocol => :http,
                 :instance_port => 80,
                 :instance_protocol => :http,
+            },
+            {
+                :port => 8443,
+                :protocol => :https,
+                :instance_port => 80,
+                :instance_protocol => :http,
+                :ssl_certificate_id => load_balancer_cert.aws_object.arn
             }],
             subnets: ["test_public_subnet"],
             security_groups: ["test_security_group"],
@@ -219,6 +231,13 @@ describe Chef::Resource::LoadBalancer do
                     :instance_port => 8080,
                     :instance_protocol => :http,
                     :ssl_certificate_id => load_balancer_cert.aws_object.arn
+                },
+                {
+                    :port => 8443,
+                    :protocol => :https,
+                    :instance_port => 80,
+                    :instance_protocol => :http,
+                    :ssl_certificate_id => load_balancer_cert_2.aws_object.arn
                 }],
                 subnets: ["test_public_subnet2"],
                 security_groups: ["test_security_group2"],
@@ -262,6 +281,13 @@ describe Chef::Resource::LoadBalancer do
                 :instance_port => 8080,
                 :instance_protocol => :http,
                 :server_certificate => {arn: load_balancer_cert.aws_object.arn}
+            },
+            {
+                :port => 8443,
+                :protocol => :https,
+                :instance_port => 80,
+                :instance_protocol => :http,
+                :server_certificate => {arn: load_balancer_cert_2.aws_object.arn}
             }],
             subnets: [test_public_subnet2.aws_object],
             security_groups: [test_security_group2.aws_object],


### PR DESCRIPTION

addresses #393 and includes #394 

From a quick look, it appears that a new function was added at some point - ``` server_cert_from_spec() ``` - but not all references to ```[:server_certificate]``` were changed to use it.

Changed the references I found and pulled in the spec from @redterror 

Tested this by applying the "it works in production" method....hoping travis and the spec will test the rest. :)



