### PR TITLE
Add tagging support for the aws_auto_scaling_group resource

### DIFF
--- a/lib/chef/resource/aws_auto_scaling_group.rb
+++ b/lib/chef/resource/aws_auto_scaling_group.rb
@@ -1,6 +1,8 @@
 require 'chef/provisioning/aws_driver/aws_resource'
 
 class Chef::Resource::AwsAutoScalingGroup < Chef::Provisioning::AWSDriver::AWSResource
+  include Chef::Provisioning::AWSDriver::AWSTaggable
+
   aws_sdk_type AWS::AutoScaling::Group
 
   attribute :name,                        kind_of: String,  name_attribute: true


### PR DESCRIPTION
Addresses issue #478.

The docs show that the `aws_auto_scaling_group` resource should support the `aws_tags` property, but it currently does not.