### PR TITLE
fix how machine_options are specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,10 +391,12 @@ aws_subnet 'my_subnet' do
 end
 
 machine 'my_machine' do
-  machine_options bootstrap_options: {
-    subnet_id: 'my_subnet',
-    security_group_ids: ['my_sg']
-  }
+  machine_options(
+    bootstrap_options: {
+      subnet_id: 'my_subnet',
+      security_group_ids: ['my_sg']
+    }
+  )
 end
 ```
 


### PR DESCRIPTION
attempt to fix how machine_options is specified in the README, yes the previous incarnation works, but fails after trying to add more machine_options which leads to confusing "bugs" like this (https://github.com/chef/chef-provisioning/issues/481) where the other options don't get picked up 