### PR TITLE
prototype - Add SOA and NS support back to route53

### DIFF
--- a/lib/chef/resource/aws_route53_hosted_zone.rb
+++ b/lib/chef/resource/aws_route53_hosted_zone.rb
@@ -126,7 +126,7 @@ class Chef::Provider::AwsRoute53HostedZone < Chef::Provisioning::AWSDriver::AWSP
       if record_set_resources
         populate_zone_info(record_set_resources, zone)
 
-        change_list = record_set_resources.map { |rs| rs.to_aws_change_struct(CREATE) }
+        change_list = record_set_resources.map { |rs| rs.to_aws_change_struct(UPDATE) }
 
         new_resource.driver.route53_client.change_resource_record_sets(hosted_zone_id: new_resource.aws_route53_zone_id,
                                                                        change_batch: {

--- a/lib/chef/resource/aws_route53_record_set.rb
+++ b/lib/chef/resource/aws_route53_record_set.rb
@@ -81,10 +81,10 @@ class Chef::Resource::AwsRoute53RecordSet < Chef::Provisioning::AWSDriver::Super
                       "CNAME records may only have a single value (a hostname).")
 
 
-    when "SOA", "TXT", "PTR", "AAAA", "SPF"
+    when "SOA", "NS", "TXT", "PTR", "AAAA", "SPF"
       true
     else
-      raise ArgumentError, "Argument '#{type}' must be one of #{%w(SOA A MX SRV CNAME TXT PTR AAAA SPF)}"
+      raise ArgumentError, "Argument '#{type}' must be one of #{%w(SOA NS A MX SRV CNAME TXT PTR AAAA SPF)}"
     end
   end
 

--- a/lib/chef/resource/aws_route53_record_set.rb
+++ b/lib/chef/resource/aws_route53_record_set.rb
@@ -80,10 +80,11 @@ class Chef::Resource::AwsRoute53RecordSet < Chef::Provisioning::AWSDriver::Super
                 raise(::Chef::Exceptions::ValidationFailed,
                       "CNAME records may only have a single value (a hostname).")
 
-    when "TXT", "PTR", "AAAA", "SPF"
+
+    when "SOA", "TXT", "PTR", "AAAA", "SPF"
       true
     else
-      raise ArgumentError, "Argument '#{type}' must be one of #{%w(A MX SRV CNAME TXT PTR AAAA SPF)}"
+      raise ArgumentError, "Argument '#{type}' must be one of #{%w(SOA A MX SRV CNAME TXT PTR AAAA SPF)}"
     end
   end
 


### PR DESCRIPTION

workaround for removed SOA/NS as discussed in #489  

re-adds NS and SOA support, switches to always use UPSERT instead of create.

please be warned - UPSERT could have unintended side effects, I'm not sure what the more global impact of this might be - and I welcome discussion and/or pointers on where to hook "if SOA or NS and already exist then do UPSERT" type logic. :)

In the meantime - works for me in production.

