### PR TITLE
Add support for RDS creation from DB snapshot

### DIFF
--- a/chef-provisioning-aws.gemspec
+++ b/chef-provisioning-aws.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'chef-provisioning', '~> 1.4'
 
   s.add_dependency 'aws-sdk-v1', '>= 1.59.0'
-  s.add_dependency 'aws-sdk', ['>= 2.1.26', '< 3.0']
+  s.add_dependency 'aws-sdk', ['>= 2.2.18', '< 3.0']
   s.add_dependency 'retryable', '~> 2.0', '>= 2.0.1'
   s.add_dependency 'ubuntu_ami', '~> 0.4', '>= 0.4.1'
 

--- a/lib/chef/provisioning/aws_driver/version.rb
+++ b/lib/chef/provisioning/aws_driver/version.rb
@@ -1,7 +1,7 @@
 class Chef
 module Provisioning
 module AWSDriver
-  VERSION = '1.11.0'
+  VERSION = '1.11.1'
 end
 end
 end

--- a/lib/chef/resource/aws_rds_instance.rb
+++ b/lib/chef/resource/aws_rds_instance.rb
@@ -8,6 +8,7 @@ class Chef::Resource::AwsRdsInstance < Chef::Provisioning::AWSDriver::AWSRDSReso
 
   attribute :db_instance_identifier, kind_of: String, name_attribute: true
 
+  attribute :db_snapshot_identifier, kind_of: String
   attribute :engine, kind_of: String
   attribute :engine_version, kind_of: String
   attribute :db_instance_class, kind_of: String


### PR DESCRIPTION
Currently, in the chef-provision-aws there is no possibility to create AWS RDS instance, basing on existing DB snapshot - they new instances are always expected to be created from scratch.

The PR is based on a private fork rebased from the latest released  1.x version of chef-provisioning-aws (1.11.0), as for the moment we can not update to Ruby 2.2.5 on our instances

This  PR is targeted to provide support for creating RDS instances from the snapshot if it was specified as parameter for the resource. It also updates the minimal required version of AWS-SDK Ruby gem in Gem spec as  default value (2.1.26) is no longer compatible with chef-provisioning-aws 1.11.0 and higher.

The code has been tested and is already used for provisioning our current instances of RDS since last 3-4 month.
