### PR TITLE
Create multiple instances using one call when using machine_batch (#306)

### DIFF
--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -1520,7 +1520,7 @@ EOD
     end
 
     def create_instance_and_reference(bootstrap_options, action_handler, machine_spec, machine_options)
-      instance = create_instances(bootstrap_options)
+      instance = create_instances(bootstrap_options).first
       instance.wait_until_exists
       create_instance_reference(instance, bootstrap_options, action_handler, machine_spec, machine_options)
       instance

--- a/spec/integration/machine_batch_spec.rb
+++ b/spec/integration/machine_batch_spec.rb
@@ -35,6 +35,5 @@ describe Chef::Resource::MachineBatch do
         ).and be_idempotent
       end
     end
-
   end
 end


### PR DESCRIPTION
Prior to this change each EC2 instance was created by making a separate `#create_instances` call.  This approach is preferred when utilizing placement groups per Amazon's recommendations below:

> First, you create a placement group and then you launch multiple instances into the placement group. We recommend that you launch the number of instances that you need in the placement group in a single launch request and that you use the same instance type for all instances in the placement group. If you try to add more instances to the placement group later, or if you try to launch more than one instance type in the placement group, you increase your chances of getting an insufficient capacity error.
 
I attempted to run the integration tests with a live EC2 accounts before making these changes, unfortunately many of them failed sporadically due to what appears to race conditions around the duration of provisioning.

Related #17