### PR TITLE
Symbolize keys of bootstrap_options before access.

### DIFF
--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -849,7 +849,7 @@ EOD
     end
 
     def bootstrap_options_for(action_handler, machine_spec, machine_options)
-      bootstrap_options = (machine_options[:bootstrap_options] || {}).to_h.dup
+      bootstrap_options = symbolize_keys(machine_options[:bootstrap_options] || {})
       # These are hardcoded for now - only 1 machine at a time
       bootstrap_options[:min_count] = bootstrap_options[:max_count] = 1
       bootstrap_options[:instance_type] ||= default_instance_type
@@ -1565,6 +1565,15 @@ EOD
       result[:instance_protocol] ||= result[:protocol]
 
       result
+    end
+
+    def symbolize_keys(hash)
+      new_hash = {}
+      hash.each do |k, v|
+        v = symbolize_keys(v) if v.is_a?(Hash)
+        new_hash[k.to_sym] = v
+      end
+      new_hash
     end
 
     def default_instance_type


### PR DESCRIPTION


I hit this issue trying to use machine_options like so:

```ruby
machine_batch do
  machine "some-machine" do
    converge true

    machine_options bootstrap_options: {
      instance_type: "r3.xlarge",
      subnet_id: "subnet-name",
      security_group_ids: ["sec-group-name"],
    }
  end
end
```

The aws object id lookup was failing for subnet_id, and the instance_type was defaulting to t2.micro.

Digging in a bit, I discovered that all the options I was setting had strings for keys by the time it gets to this method, as a result of calling `Cheffish::MergedConfig#to_h`, so all of the subsequent checks were failing.

Perhaps there's a more elegant fix up the stack (i.e. chef-provisioning not using Cheffish::MergedConfig), but I'm not seeing how this was introduced so I'm not sure. From what I'm looking at, I don't see how this ever worked, so maybe I'm missing something.
