### PR TITLE
Fixed the credentials file environment variable name.

### DIFF
--- a/lib/chef/provisioning/aws_driver/credentials.rb
+++ b/lib/chef/provisioning/aws_driver/credentials.rb
@@ -98,7 +98,7 @@ module AWSDriver
 
     def load_default
       config_file = ENV['AWS_CONFIG_FILE'] || File.expand_path('~/.aws/config')
-      credentials_file = ENV['AWS_CREDENTIAL_FILE'] || File.expand_path('~/.aws/credentials')
+      credentials_file = ENV['AWS_SHARED_CREDENTIALS_FILE'] || ENV['AWS_CREDENTIAL_FILE'] || File.expand_path('~/.aws/credentials')
       if File.file?(config_file)
         if File.file?(credentials_file)
           load_inis(config_file, credentials_file)

--- a/lib/chef/provisioning/aws_driver/credentials2.rb
+++ b/lib/chef/provisioning/aws_driver/credentials2.rb
@@ -27,7 +27,11 @@ module AWSDriver
     # can be loaded successfully.
     def get_credentials
       # http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-environment
-      shared_creds = ::Aws::SharedCredentials.new(:profile_name => profile_name, :path => ENV["AWS_CONFIG_FILE"])
+      credentials_file = ENV.fetch('AWS_SHARED_CREDENTIALS_FILE', ENV['AWS_CONFIG_FILE'])
+      shared_creds = ::Aws::SharedCredentials.new(
+        :profile_name => profile_name,
+        :path => credentials_file
+      )
       instance_profile_creds = ::Aws::InstanceProfileCredentials.new(:retries => 1)
 
       if ENV["AWS_ACCESS_KEY_ID"] && ENV["AWS_SECRET_ACCESS_KEY"]

--- a/spec/unit/chef/provisioning/aws_driver/credentials_spec.rb
+++ b/spec/unit/chef/provisioning/aws_driver/credentials_spec.rb
@@ -150,6 +150,19 @@ describe Chef::Provisioning::AWSDriver::Credentials do
       %w(work_iam personal).each do |profile|
         it "loads the '#{profile}' profile from a separate config files" do
           ENV['AWS_DEFAULT_PROFILE'] = profile
+          ENV['AWS_SHARED_CREDENTIALS_FILE'] = credential_ini_file.path
+          ENV['AWS_CONFIG_FILE'] = config_ini_file.path
+
+          expect(described_class.new.default)
+            .to eq(send("#{profile}_credentials"))
+        end
+      end
+    end
+
+    context 'backwards compatibility for AWS_CREDENTIAL_FILE env var' do
+      %w(work_iam personal).each do |profile|
+        it "loads the '#{profile}' profile from a separate config files" do
+          ENV['AWS_DEFAULT_PROFILE'] = profile
           ENV['AWS_CREDENTIAL_FILE'] = credential_ini_file.path
           ENV['AWS_CONFIG_FILE'] = config_ini_file.path
 


### PR DESCRIPTION
The AWS_CREDENTIAL_FILE environment variable isn't the right variable to load a custom path to a credentials file. The correct variable is AWS_SHARED_CREDENTIALS_FILE.

See the discussion here for more background: https://github.com/aws/aws-cli/issues/1037

I retained support for AWS_CREDENTIAL_FILE so that this doesn't introduce a backwards incompatible change.