### PR TITLE
aws_rds_instance - update to support modify, and wait for create

### DIFF
--- a/lib/chef/provider/aws_rds_instance.rb
+++ b/lib/chef/provider/aws_rds_instance.rb
@@ -6,48 +6,128 @@ class Chef::Provider::AwsRdsInstance < Chef::Provisioning::AWSDriver::AWSProvide
 
   provides :aws_rds_instance
 
+  ## any new first class attributes that should be passed to rds should be added here.  these are used to assemble options_hash
   REQUIRED_OPTIONS = %i(db_instance_identifier allocated_storage engine
                         db_instance_class master_username master_user_password)
 
   OTHER_OPTIONS = %i(engine_version multi_az iops publicly_accessible db_name port db_subnet_group_name db_parameter_group_name)
 
+
+## update (and therefor modify) will ALWAYS called on any run after a create
+## there's no sane ability to compare desired state vs current state without extensive per-option logic
+## calling modify (even with/without apply_immediately) is safe - it only
+## "updates" the master password (modify has know way to determine the previous
+## one, of course), which is effectively a non-op.
   def update_aws_object(instance)
-    Chef::Log.warn("aws_rds_instance does not support modifying a started instance")
-    # There are required optiosn (like `allocated_storage`) that the use may not
-    # specify on a resource to perform an update.  For example, they may want to
-    # only specify iops to modify that attribute on an update after initial
-    # creation.  In this case we need to load the required options from the existing
-    # aws_object and only override it if the user has specified a value in the
-    # resource.  Ideally, it would be nice to mark values as required on the
-    # resource but right now there is not a `required_on_create`.  This would
-    # also be different if chef-provisioning performed resource cloning, which
-    # it does not.
-  end
+
+    ### these options need to be transformed...this could get hairy?
+    ### create and modify use different names for them.
+    ### and re-naming an instance could definitely get weird.
+    # db_instance_identifier - create
+    # new_db_instance_identifier - modify
+    # port - create
+    # db_port_number - modify
+
+    ## remove create specific options we can't pass to modify
+    [:engine, :master_username, :db_subnet_group_name, :availability_zone, :character_set_name, :db_cluster_identifier, :db_name, :kms_key_id, :storage_encrypted, :tags, :timezone].each do |key|
+      options_hash.delete(key)
+    end
+
+    ## always wait for a safe state (available) before we try to apply a modification.
+    wait_for(
+      aws_object: instance,
+      query_method: :db_instance_status,
+      expected_responses: ['available'],
+      tries: new_resource.wait_tries,
+      sleep: new_resource.wait_time
+    ) { |instance|
+      instance.reload
+      Chef::Log.info "Update RDS instance: before update, waiting for #{new_resource.db_instance_identifier} to be available.  State: #{instance.db_instance_status} - pending: #{instance.pending_modified_values.to_h}" if instance.db_instance_status != "available"
+    }
+
+    updated={} #so we can use this outside the converge_by
+    converge_by "update RDS instance #{new_resource.db_instance_identifier} in #{region}" do
+      updated=new_resource.driver.rds_client.modify_db_instance(options_hash).to_h[:db_instance]
+    end
+
+    if new_resource.wait_for_update
+      slept=false
+      ## use the response from modify to determine if we applied an update we should wait for
+      updated[:pending_modified_values].each do |k, v|
+        ## we ALWAYS apply an update, but we dont need to "wait" for the master_user_password (or do we?)
+        if k.to_s != "master_user_password"
+          if ! slept  #maybe we should just break the loop?
+            Chef::Log.info "Updated RDS instance: #{new_resource.db_instance_identifier}, sleeping #{new_resource.wait_time} seconds to verify state is now available due to #{updated[:pending_modified_values]}"
+            sleep new_resource.wait_time  #it takes a few seconds before the instance goes out of 'available'
+            slept=true
+          end
+          converge_by "waiting until RDS instance is available after update" do
+            wait_for(
+              aws_object: instance,
+              query_method: :db_instance_status,
+              expected_responses: ['available'],
+              tries: new_resource.wait_tries,
+              sleep: new_resource.wait_time
+            ) { |instance|
+              instance.reload
+              Chef::Log.info "Update RDS instance, waiting for #{new_resource.db_instance_identifier} to be available. State: #{instance.db_instance_status} - pending: #{instance.pending_modified_values.to_h}"
+            }
+          end
+        end
+      end
+    end
+
+  end #def update
 
   def create_aws_object
+
+    ## remove modify specific options we can't pass to create
+    [:apply_immediately, :allow_major_version_upgrade, :ca_certificate_identifier ].each do |key|
+      options_hash.delete(key)
+    end
+
+    Chef::Log.info "Create RDS instance: #{new_resource.db_instance_identifier}"
+
     converge_by "create RDS instance #{new_resource.db_instance_identifier} in #{region}" do
       new_resource.driver.rds_resource.create_db_instance(options_hash)
     end
-  end
+
+    if new_resource.wait_for_create
+      converge_by "waiting until RDS instance is available after create" do
+        wait_for(
+          aws_object: instance,
+          query_method: :db_instance_status,
+          expected_responses: ['available'],
+          tries: new_resource.wait_tries,
+          sleep: new_resource.wait_time
+        ) { |instance|
+            instance.reload
+            Chef::Log.info "Create RDS instance: waiting for #{new_resource.db_instance_identifier} to be available.  State: #{instance.db_instance_status} - pending: #{instance.pending_modified_values.to_h}"
+          }
+      end
+    end
+  end #def create
 
   def destroy_aws_object(instance)
     converge_by "delete RDS instance #{new_resource.db_instance_identifier} in #{region}" do
       instance.delete(skip_final_snapshot: true)
     end
-    # Wait up to 10 minutes for the db instance to shutdown
-    converge_by "waited until RDS instance #{new_resource.name} was deleted" do
-      wait_for(
-        aws_object: instance,
-        # http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.Status.html
-        # It cannot _actually_ return a deleted status, we're just looking for the error
-        query_method: :db_instance_status,
-        expected_responses: ['deleted'],
-        acceptable_errors: [::Aws::RDS::Errors::DBInstanceNotFound],
-        tries: 60,
-        sleep: 10
-      ) { |instance| instance.reload }
+    if new_resource.wait_for_delete
+      # Wait up to sleep * tries / 60 minutes for the db instance to shutdown
+      converge_by "waited until RDS instance #{new_resource.name} was deleted" do
+        wait_for(
+          aws_object: instance,
+          # http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.Status.html
+          # It cannot _actually_ return a deleted status, we're just looking for the error
+          query_method: :db_instance_status,
+          expected_responses: ['deleted'],
+          acceptable_errors: [::Aws::RDS::Errors::DBInstanceNotFound],
+          tries: new_resource.wait_tries,
+          sleep: new_resource.wait_time
+        ) { |instance| instance.reload }
+      end
     end
-  end
+  end #def destroy
 
   # Sets the additional options then overrides it with all required options from
   # the resource as well as optional options

--- a/lib/chef/resource/aws_rds_instance.rb
+++ b/lib/chef/resource/aws_rds_instance.rb
@@ -42,6 +42,7 @@ class Chef::Resource::AwsRdsInstance < Chef::Provisioning::AWSDriver::AWSRDSReso
   attribute :wait_time, kind_of: Integer, default: 10
   attribute :wait_tries, kind_of: Integer, default: 600
 
+  attribute :skip_final_snapshot, kind_of: [TrueClass, FalseClass], default: true
 
   def aws_object
     result = self.driver.rds_resource.db_instance(name)

--- a/lib/chef/resource/aws_rds_instance.rb
+++ b/lib/chef/resource/aws_rds_instance.rb
@@ -6,6 +6,7 @@ class Chef::Resource::AwsRdsInstance < Chef::Provisioning::AWSDriver::AWSRDSReso
 
   aws_sdk_type ::Aws::RDS::DBInstance, id: :db_instance_identifier
 
+  ## first class attributes for RDS parameters
   attribute :db_instance_identifier, kind_of: String, name_attribute: true
 
   attribute :engine, kind_of: String
@@ -29,6 +30,18 @@ class Chef::Resource::AwsRdsInstance < Chef::Provisioning::AWSDriver::AWSRDSReso
   # RDS has a ton of options, allow users to set any of them via a
   # custom Hash
   attribute :additional_options, kind_of: Hash, default: {}
+
+  ## aws_rds_instance specific attributes
+  ##the existing state
+  attribute :wait_for_create, kind_of: [TrueClass, FalseClass], default: false
+  attribute :wait_for_delete, kind_of: [TrueClass, FalseClass], default: true
+  #and new - wait for update by default
+  attribute :wait_for_update, kind_of: [TrueClass, FalseClass], default: true
+  # when we wait - how times we retry and how long we sleep between retries
+  # this is long by default because a lot of modifications, ie instance up/downgrade, take a long time.
+  attribute :wait_time, kind_of: Integer, default: 10
+  attribute :wait_tries, kind_of: Integer, default: 600
+
 
   def aws_object
     result = self.driver.rds_resource.db_instance(name)


### PR DESCRIPTION
TODO:  
* merge master and update to support restore from snapshot functionality.
* update documentation
* include examples

Incomplete due to changes in master, but otherwise working for me in an older fork.   

Previously, rds was create-only, no modifications would apply.   this adds logic to handle update.   Also added options around waiting for update/create/delete to complete, and logic to wait for create.  

Note that updates (modify) are -always- run on every convergence, because we cannot sanely compare current to desired state.   In reality, this means that the master password is 'updated' every run - but no other state changes actually apply unless they need to.   

Users will definitely want to review their `additional_options( apply_immediately: ... )` state - this defaults to applying during the maint window.


