### PR TITLE
Fixes bug preventing disassociating eips.

### DIFF
--- a/lib/chef/provider/aws_eip_address.rb
+++ b/lib/chef/provider/aws_eip_address.rb
@@ -79,7 +79,7 @@ class Chef::Provider::AwsEipAddress < Chef::Provisioning::AWSDriver::AWSProvider
     else
       if elastic_ip.associated?
         converge_by "disassociate Elastic IP address #{new_resource.name} (#{elastic_ip.public_ip}) from #{elastic_ip.instance_id} in #{region}" do
-          aws_object.disassociate
+          elastic_ip.disassociate
         end
       end
     end


### PR DESCRIPTION
Without this fix, the disassociating an eip like so:

```ruby
  aws_eip_address "some-eip" do
    machine false
  end
``` 

Results in:

```
    NameError
    ---------
    No resource, method, or local variable named `aws_object' for `Chef::Provider::AwsEipAddress ""'
```