### PR TITLE
correctly symbolize bootstrap_options, making chef13 go again

### DIFF
--- a/lib/chef/provisioning/aws_driver/aws_provider.rb
+++ b/lib/chef/provisioning/aws_driver/aws_provider.rb
@@ -29,7 +29,7 @@ class AWSProvider < Chef::Provider::LWRPBase
   end
 
   def region
-    new_resource.driver.aws_config.region
+    new_resource.driver.aws_config[:region]
   end
 
   #

--- a/lib/chef/provisioning/aws_driver/aws_resource.rb
+++ b/lib/chef/provisioning/aws_driver/aws_resource.rb
@@ -100,8 +100,9 @@ module AWSDriver
             options[name] = [options[name]].flatten.map { |value| aws_option_handlers[handler_name].get_aws_object_id(value, **handler_options) }
           end
         else
-          if aws_option_handlers[name]
-            options[name] = aws_option_handlers[name].get_aws_object_id(value, **handler_options)
+          handler_name = name.to_sym
+          if aws_option_handlers[handler_name]
+            options[handler_name] = aws_option_handlers[handler_name].get_aws_object_id(value, **handler_options)
           end
         end
       end

--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -1274,6 +1274,7 @@ EOD
       convergence_options = Cheffish::MergedConfig.new(
         machine_options[:convergence_options] || {},
         ohai_hints: { 'ec2' => '' })
+      convergence_options=deep_symbolize_keys(convergence_options)
 
       # Defaults
       if !machine_spec.reference

--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -204,7 +204,7 @@ module AWSDriver
         perform_action = proc { |desc, &block| action_handler.perform_action(desc, &block) }
         Chef::Log.debug "AWS Load Balancer options: #{lb_options.inspect}"
 
-        updates = [ "create load balancer #{lb_spec.name} in #{aws_config.region}" ]
+        updates = [ "create load balancer #{lb_spec.name} in #{aws_config[:region]}" ]
         updates << "  enable availability zones #{lb_options[:availability_zones]}" if lb_options[:availability_zones]
         updates << "  attach subnets #{lb_options[:subnets].join(', ')}" if lb_options[:subnets]
         updates << "  with listeners #{lb_options[:listeners]}" if lb_options[:listeners]
@@ -227,7 +227,7 @@ module AWSDriver
         # Header gets printed the first time we make an update
         perform_action = proc do |desc, &block|
           perform_action = proc { |desc, &block| action_handler.perform_action(desc, &block) }
-          action_handler.perform_action [ "Update load balancer #{lb_spec.name} in #{aws_config.region}", desc ].flatten, &block
+          action_handler.perform_action [ "Update load balancer #{lb_spec.name} in #{aws_config[:region]}", desc ].flatten, &block
         end
 
         # TODO: refactor this whole giant method into many smaller method calls
@@ -482,7 +482,7 @@ module AWSDriver
         if instances_to_add.size > 0
           perform_action.call("  add machines #{instances_to_add.map { |s| s.name }.join(', ')}") do
             instance_ids_to_add = instances_to_add.map { |s| s.reference['instance_id'] }
-            Chef::Log.debug("Adding instances #{instance_ids_to_add.join(', ')} to load balancer #{actual_elb.name} in region #{aws_config.region}")
+            Chef::Log.debug("Adding instances #{instance_ids_to_add.join(', ')} to load balancer #{actual_elb.name} in region #{aws_config[:region]}")
             actual_elb.instances.add(instance_ids_to_add)
           end
         end
@@ -677,7 +677,7 @@ EOD
       bootstrap_options = bootstrap_options_for(action_handler, machine_spec, machine_options)
 
       if instance == nil || !instance.exists? || instance.state.name == "terminated"
-        action_handler.perform_action "Create #{machine_spec.name} with AMI #{bootstrap_options[:image_id]} in #{aws_config.region}" do
+        action_handler.perform_action "Create #{machine_spec.name} with AMI #{bootstrap_options[:image_id]} in #{aws_config[:region]}" do
           Chef::Log.debug "Creating instance with bootstrap options #{bootstrap_options}"
           instance = create_instance_and_reference(bootstrap_options, action_handler, machine_spec, machine_options)
         end
@@ -704,7 +704,7 @@ EOD
       if instance.state.name != "running"
         wait_until_machine(action_handler, machine_spec, "finish stopping", instance) { |instance| instance.state.name != "stopping" }
         if instance.state.name == "stopped"
-          action_handler.perform_action "Start #{machine_spec.name} (#{machine_spec.reference['instance_id']}) in #{aws_config.region} ..." do
+          action_handler.perform_action "Start #{machine_spec.name} (#{machine_spec.reference['instance_id']}) in #{aws_config[:region]} ..." do
             instance.start
           end
         end
@@ -747,7 +747,7 @@ EOD
       if instance && instance.exists?
         wait_until_machine(action_handler, machine_spec, "finish coming up so we can stop it", instance) { |instance| instance.state.name != "pending" }
         if instance.state.name == "running"
-          action_handler.perform_action "Stop #{machine_spec.name} (#{instance.id}) in #{aws_config.region} ..." do
+          action_handler.perform_action "Stop #{machine_spec.name} (#{instance.id}) in #{aws_config[:region]} ..." do
             instance.stop
           end
         end
@@ -828,7 +828,7 @@ EOD
       @auto_scaling ||= AWS::AutoScaling.new(config: aws_config)
     end
 
-    def build_arn(partition: 'aws', service: nil, region: aws_config.region, account_id: self.account_id, resource: nil)
+    def build_arn(partition: 'aws', service: nil, region: aws_config[:region], account_id: self.account_id, resource: nil)
       "arn:#{partition}:#{service}:#{region}:#{account_id}:#{resource}"
     end
 
@@ -881,7 +881,7 @@ EOD
       # These are hardcoded for now - only 1 machine at a time
       bootstrap_options[:min_count] = bootstrap_options[:max_count] = 1
       bootstrap_options[:instance_type] ||= default_instance_type
-      image_id = machine_options[:from_image] || bootstrap_options[:image_id] || machine_options[:image_id] || default_ami_for_region(aws_config.region)
+      image_id = machine_options[:from_image] || bootstrap_options[:image_id] || machine_options[:image_id] || default_ami_for_region(aws_config[:region])
       bootstrap_options[:image_id] = image_id
       bootstrap_options.delete(:key_path)
       if !bootstrap_options[:key_name]

--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -161,12 +161,22 @@ module AWSDriver
     end
 
     def deep_symbolize_keys(hash_like)
+      # Process arrays first...
+      if hash_like.is_a?(Array)
+        hash_like.length.times do |e|
+          hash_like[e]=deep_symbolize_keys(hash_like[e]) if hash_like[e].respond_to?(:values) or hash_like[e].is_a?(Array)
+        end
+        return hash_like
+      end
+      # Otherwise return ourselves if not a hash
+      return hash_like if not hash_like.respond_to?(:values)
+      # Otherwise we are hash like, push on through...
       if hash_like.nil? || hash_like.empty?
         return {}
       end
       r = {}
       hash_like.each do |key, value|
-        value = deep_symbolize_keys(value) if value.respond_to?(:values)
+        value = deep_symbolize_keys(value) if value.respond_to?(:values) or value.is_a?(Array)
         r[key.to_sym] = value
       end
       r

--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -948,7 +948,7 @@ EOD
       end
 
       Chef::Log.debug "AWS Bootstrap options: #{bootstrap_options.inspect}"
-      bootstrap_options
+      deep_symbolize_keys(bootstrap_options)
     end
 
     def default_ssh_username

--- a/lib/chef/provisioning/aws_driver/tagging_strategy/rds.rb
+++ b/lib/chef/provisioning/aws_driver/tagging_strategy/rds.rb
@@ -26,7 +26,7 @@ module Chef::Provisioning::AWSDriver::TaggingStrategy
     # http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.html#USER_Tagging.ARN
     def construct_arn(new_resource)
       @arn ||= begin
-        region = new_resource.driver.aws_config.region
+        region = new_resource.driver.aws_config[:region]
         name = new_resource.name
         rds_type = new_resource.rds_tagging_type
         # Taken from example on https://forums.aws.amazon.com/thread.jspa?threadID=108012


### PR DESCRIPTION
correctly symbolize bootstrap_options, making chef13 go again - this one was missed in the symbolizing!

This set of changes allows current chef13/cheffish13 to correctly provision AWS machines