### PR TITLE
Fixed 'load_balancer.rb' syntax error on line 71

### DIFF
--- a/docs/examples/load_balancer.rb
+++ b/docs/examples/load_balancer.rb
@@ -68,5 +68,4 @@ load_balancer "test-elb" do
        }
       end
     )
-  end
 end


### PR DESCRIPTION
Deleted the 'end' keyword on line 71. Because it does not match any 'do' keywords in the context.