### PR TITLE
Fixing load_balancer deregister and tests

### DIFF
--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -616,7 +616,8 @@ module AWSDriver
 
         if instance_ids_to_remove.size > 0
           perform_action.call("  remove instances #{instance_ids_to_remove}") do
-            actual_elb.instances.remove(instance_ids_to_remove)
+            instances_to_remove = Hash[instance_ids_to_remove.map {|id| [:instance_id, id]}]
+            elb.deregister_instances_from_load_balancer({ instances: [instances_to_remove], load_balancer_name: actual_elb.load_balancer_name})
           end
         end
       end

--- a/spec/integration/load_balancer_spec.rb
+++ b/spec/integration/load_balancer_spec.rb
@@ -311,9 +311,10 @@ describe Chef::Resource::LoadBalancer do
               })
               machines ['test_load_balancer_machine1']
             end
-          }.to create_an_aws_load_balancer('test-load-balancer',
-            :instances => [{id: test_load_balancer_machine1.aws_object.id}]
-          ).and be_idempotent
+          }.to create_an_aws_load_balancer('test-load-balancer') { |aws_object|
+            ids = aws_object.instances.map {|i| i.instance_id}
+            expect([test_load_balancer_machine1.aws_object.id]).to eq(ids)
+          }.and be_idempotent
         end
 
         it "can reference machines by name or id" do
@@ -326,8 +327,7 @@ describe Chef::Resource::LoadBalancer do
               machines ['test_load_balancer_machine1', test_load_balancer_machine2.aws_object.id]
             end
           }.to create_an_aws_load_balancer('test-load-balancer') { |aws_object|
-            instances = aws_object.instances
-            ids = instances.map {|i| i.id}
+            ids = aws_object.instances.map {|i| i.instance_id}
             expect(ids.to_set).to eq([test_load_balancer_machine1.aws_object.id, test_load_balancer_machine2.aws_object.id].to_set)
           }.and be_idempotent
         end
@@ -350,9 +350,10 @@ describe Chef::Resource::LoadBalancer do
                 })
                 machines ['test_load_balancer_machine2']
               end
-            }.to match_an_aws_load_balancer('test-load-balancer',
-              :instances => [{id: test_load_balancer_machine2.aws_object.id}]
-            ).and be_idempotent
+            }.to match_an_aws_load_balancer('test-load-balancer') { |aws_object|
+              ids = aws_object.instances.map {|i| i.instance_id}
+              expect([test_load_balancer_machine2.aws_object.id]).to eq(ids)
+            }.and be_idempotent
           end
         end
       end


### PR DESCRIPTION
I found these test failing when running with `-t super_slow`. I'm pretty sure the `deregister_instances_from_load_balancer` change is right but my tests are still failing with errors I don't understand when I run them.