### PR TITLE
Fix for failing specs

### DIFF
--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -69,7 +69,7 @@ class Provider
     # We override this so we can specify a machine name as `i-123456`
     # This is totally a hack until we move away from base resources
     def get_machine_spec!(machine_name)
-      if machine_name =~ /^i-[a-f0-9]{8}$/
+      if machine_name =~ /^i-[0-9a-f]{8}/
         Struct.new(:name, :reference).new(machine_name, {'instance_id' => machine_name})
       else
         Chef::Log.debug "Getting machine spec for #{machine_name}"

--- a/spec/integration/aws_route_table_spec.rb
+++ b/spec/integration/aws_route_table_spec.rb
@@ -33,7 +33,7 @@ describe Chef::Resource::AwsRouteTable do
         }.to create_an_aws_route_table('test_route_table',
           routes: Set[
             { destination_cidr_block: '10.0.0.0/16', gateway_id: 'local', state: "active" },
-            { destination_cidr_block: '0.0.0.0/0', gateway_id: test_vpc.aws_object.internet_gateway.id, state: "active" }
+            { destination_cidr_block: '0.0.0.0/0', gateway_id: test_vpc.aws_object.internet_gateways.first.id, state: "active" }
           ]
         ).and be_idempotent
       end
@@ -57,7 +57,7 @@ describe Chef::Resource::AwsRouteTable do
             routes: Set[
               { destination_cidr_block: '10.0.0.0/16', gateway_id: 'local', state: "active" },
               { destination_cidr_block: '172.31.0.0/16', network_interface_id: test_network_interface.aws_object.id, state: "blackhole" },
-              { destination_cidr_block: '0.0.0.0/0', gateway_id: test_vpc.aws_object.internet_gateway.id, state: "active" },
+              { destination_cidr_block: '0.0.0.0/0', gateway_id: test_vpc.aws_object.internet_gateways.first.id, state: "active" },
             ]
           ).and be_idempotent
       end
@@ -78,9 +78,9 @@ describe Chef::Resource::AwsRouteTable do
             end
           }.to update_an_aws_route_table('test_route_table',
             routes: Set[
-              { destination_cidr_block: '2.0.0.0/8', gateway_id: test_vpc.aws_object.internet_gateway.id, state: "active" },
+              { destination_cidr_block: '2.0.0.0/8', gateway_id: test_vpc.aws_object.internet_gateways.first.id, state: "active" },
               { destination_cidr_block: '10.0.0.0/16', gateway_id: 'local', state: "active" },
-              { destination_cidr_block: '0.0.0.0/0', gateway_id: test_vpc.aws_object.internet_gateway.id, state: "active" },
+              { destination_cidr_block: '0.0.0.0/0', gateway_id: test_vpc.aws_object.internet_gateways.first.id, state: "active" },
             ]
           ).and be_idempotent
         end
@@ -129,7 +129,7 @@ describe Chef::Resource::AwsRouteTable do
             routes: Set[
                 { destination_cidr_block: '10.0.0.0/16', gateway_id: 'local', state: "active" },
                 { destination_cidr_block: '11.0.0.0/8', instance_id: test_machine.aws_object.id, state: "active" },
-                { destination_cidr_block: '0.0.0.0/0', gateway_id: test_vpc.aws_object.internet_gateway.id, state: "active" },
+                { destination_cidr_block: '0.0.0.0/0', gateway_id: test_vpc.aws_object.internet_gateways.first.id, state: "active" },
               ]
           ).and be_idempotent
         end
@@ -217,7 +217,7 @@ describe Chef::Resource::AwsRouteTable do
           routes: Set[
             { destination_cidr_block: '10.0.0.0/24', gateway_id: 'local', state: "active" },
             { destination_cidr_block: '100.100.0.0/16', vpc_peering_connection_id: pcx.aws_object.id, state: "active" },
-            { destination_cidr_block: '0.0.0.0/0', gateway_id: test_vpc_1.aws_object.internet_gateway.id, state: "active" }
+            { destination_cidr_block: '0.0.0.0/0', gateway_id: test_vpc_1.aws_object.internet_gateways.first.id, state: "active" }
           ]
         ).and be_idempotent
       end

--- a/spec/integration/load_balancer_spec.rb
+++ b/spec/integration/load_balancer_spec.rb
@@ -311,7 +311,7 @@ describe Chef::Resource::LoadBalancer do
               })
               machines ['test_load_balancer_machine1']
             end
-          }.to create_an_aws_load_balancer('test-load-balancer') { |aws_object|
+          }.to create_an_aws_load_balancer('test-load-balancer', driver.elb_client.describe_load_balancers(load_balancer_names: ["test-load-balancer"])[0][0]) { |aws_object|
             ids = aws_object.instances.map {|i| i.instance_id}
             expect([test_load_balancer_machine1.aws_object.id]).to eq(ids)
           }.and be_idempotent
@@ -326,7 +326,7 @@ describe Chef::Resource::LoadBalancer do
               })
               machines ['test_load_balancer_machine1', test_load_balancer_machine2.aws_object.id]
             end
-          }.to create_an_aws_load_balancer('test-load-balancer') { |aws_object|
+          }.to create_an_aws_load_balancer('test-load-balancer', driver.elb_client.describe_load_balancers(load_balancer_names: ["test-load-balancer"])[0][0]) { |aws_object|
             ids = aws_object.instances.map {|i| i.instance_id}
             expect(ids.to_set).to eq([test_load_balancer_machine1.aws_object.id, test_load_balancer_machine2.aws_object.id].to_set)
           }.and be_idempotent
@@ -350,7 +350,7 @@ describe Chef::Resource::LoadBalancer do
                 })
                 machines ['test_load_balancer_machine2']
               end
-            }.to match_an_aws_load_balancer('test-load-balancer') { |aws_object|
+            }.to match_an_aws_load_balancer('test-load-balancer', driver.elb_client.describe_load_balancers(load_balancer_names: ["test-load-balancer"])[0][0]) { |aws_object|
               ids = aws_object.instances.map {|i| i.instance_id}
               expect([test_load_balancer_machine2.aws_object.id]).to eq(ids)
             }.and be_idempotent


### PR DESCRIPTION
This PR contains fix for failing specs for load balancer and route table. Also fixed regular expression which was used to match instance id.

Signed-off-by: Vasu1105 <vasundhara.jagdale@msystechnologies.com>