### PR TITLE
[MSYS-700] Migrate aws_cloudsearch_domain from v1 to v2

### DIFF
--- a/lib/chef/provider/aws_cloudsearch_domain.rb
+++ b/lib/chef/provider/aws_cloudsearch_domain.rb
@@ -177,6 +177,6 @@ class Chef::Provider::AwsCloudsearchDomain < Chef::Provisioning::AWSDriver::AWSP
   end
 
   def cs_client
-    @cs_client ||= new_resource.driver.cloudsearch(new_resource.cloudsearch_api_version)
+    @cs_client ||= new_resource.driver.cloudsearch
   end
 end

--- a/lib/chef/provider/aws_cloudsearch_domain.rb
+++ b/lib/chef/provider/aws_cloudsearch_domain.rb
@@ -81,7 +81,12 @@ class Chef::Provider::AwsCloudsearchDomain < Chef::Provisioning::AWSDriver::AWSP
 
   def update_index_fields?(domain)
     if ! new_resource.index_fields.nil?
-      new_resource.index_fields != index_fields
+      index_fields.each do |index_field|
+        if ! new_resource.index_fields.include?(index_field.to_h[:options])
+          return true
+        end
+      end
+      false
     else
       false
     end
@@ -148,8 +153,9 @@ class Chef::Provider::AwsCloudsearchDomain < Chef::Provisioning::AWSDriver::AWSP
   end
 
   def scaling_parameters(object)
-    o = get_option(:scaling_parameters)
-    o.merge(desired_instance_type: object[:search_instance_type])
+    scaling_parameters = get_option(:scaling_parameters)
+    scaling_parameters.desired_instance_type = object[:search_instance_type]
+    scaling_parameters
   end
 
   def access_policies
@@ -157,7 +163,7 @@ class Chef::Provider::AwsCloudsearchDomain < Chef::Provisioning::AWSDriver::AWSP
   end
 
   def index_fields
-    cs_client.describe_index_fields(domain_name: new_resource.name)[:index_fields]
+    cs_client.describe_index_fields(domain_name: new_resource.name).index_fields
   end
 
   def get_option(option_name, key=nil)

--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -159,6 +159,12 @@ module AWSDriver
       aws_config_2[:region]
     end
 
+    def cloudsearch(api_version="20130101")
+      @cloudsearch ||= {}
+      @cloudsearch[api_version] ||= Aws::CloudSearch::Client.new
+      @cloudsearch[api_version]
+    end
+    
     def self.canonicalize_url(driver_url, config)
       [ driver_url, config ]
     end
@@ -808,12 +814,6 @@ EOD
       # TODO move this into the aws_instance provider somehow
       strategy = convergence_strategy_for(machine_spec, machine_options)
       strategy.cleanup_convergence(action_handler, machine_spec)
-    end
-
-    def cloudsearch(api_version="20130101")
-      @cloudsearch ||= {}
-      @cloudsearch[api_version] ||= ::Aws::CloudSearch::Client.const_get("V#{api_version}").new
-      @cloudsearch[api_version]
     end
 
     def ec2

--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -159,10 +159,8 @@ module AWSDriver
       aws_config_2[:region]
     end
 
-    def cloudsearch(api_version="20130101")
-      @cloudsearch ||= {}
-      @cloudsearch[api_version] ||= Aws::CloudSearch::Client.new
-      @cloudsearch[api_version]
+    def cloudsearch
+      @cloudsearch ||= Aws::CloudSearch::Client.new(aws_config)
     end
     
     def self.canonicalize_url(driver_url, config)

--- a/lib/chef/resource/aws_cloudsearch_domain.rb
+++ b/lib/chef/resource/aws_cloudsearch_domain.rb
@@ -43,4 +43,10 @@ class Chef::Resource::AwsCloudsearchDomain < Chef::Provisioning::AWSDriver::AWSR
   def aws_object
     driver.cloudsearch.describe_domains(domain_names: [name])[:domain_status_list].find {|d| !d[:deleted] }
   end
+
+  def cloudsearch_api_version(arg=nil)
+    unless arg.nil?
+      Chef::Log.warn("The ':cloudsearch_api_version' has been deprecated since it has been removed in AWS SDK version 2.")
+    end
+  end
 end


### PR DESCRIPTION
Note: @tyler-ball  @btm Added deperication warning for  cloudsearch_api_version attribute since there is no support for this in version 2 Ref http://docs.aws.amazon.com/sdkforruby/api/Aws/CloudSearch/Client.html

Signed-off-by: Vasu1105 <vasundhara.jagdale@msystechnologies.com>