### PR TITLE
Fix load balancer test failures

### DIFF
--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -616,7 +616,8 @@ module AWSDriver
 
         if instance_ids_to_remove.size > 0
           perform_action.call("  remove instances #{instance_ids_to_remove}") do
-            actual_elb.instances.remove(instance_ids_to_remove)
+            instances_to_remove = Hash[instance_ids_to_remove.map {|id| [:instance_id, id]}]
+            elb.deregister_instances_from_load_balancer({ instances: [instances_to_remove], load_balancer_name: actual_elb.load_balancer_name})
           end
         end
       end

--- a/spec/aws_support/deep_matcher/match_values_failure_messages.rb
+++ b/spec/aws_support/deep_matcher/match_values_failure_messages.rb
@@ -23,6 +23,7 @@ module AWSSupport
         elsif Set === expected
           return match_sets_failure_messages(expected, actual, identifier)
         elsif Hash === expected
+          actual = actual.to_h if Struct === actual
           return match_hashes_failure_messages(expected, actual, identifier) if Hash === actual
           return match_hash_and_object_failure_messages(expected, actual, identifier) if MatchableObject === actual
         elsif Array === expected

--- a/spec/integration/load_balancer_spec.rb
+++ b/spec/integration/load_balancer_spec.rb
@@ -311,7 +311,7 @@ describe Chef::Resource::LoadBalancer do
               })
               machines ['test_load_balancer_machine1']
             end
-          }.to create_an_aws_load_balancer('test-load-balancer', driver.elb_client.describe_load_balancers(load_balancer_names: ["test-load-balancer"])[0][0]) { |aws_object|
+          }.to create_an_aws_load_balancer('test-load-balancer') { |aws_object|
             ids = aws_object.instances.map {|i| i.instance_id}
             expect([test_load_balancer_machine1.aws_object.id]).to eq(ids)
           }.and be_idempotent
@@ -326,7 +326,7 @@ describe Chef::Resource::LoadBalancer do
               })
               machines ['test_load_balancer_machine1', test_load_balancer_machine2.aws_object.id]
             end
-          }.to create_an_aws_load_balancer('test-load-balancer', driver.elb_client.describe_load_balancers(load_balancer_names: ["test-load-balancer"])[0][0]) { |aws_object|
+          }.to create_an_aws_load_balancer('test-load-balancer') { |aws_object|
             ids = aws_object.instances.map {|i| i.instance_id}
             expect(ids.to_set).to eq([test_load_balancer_machine1.aws_object.id, test_load_balancer_machine2.aws_object.id].to_set)
           }.and be_idempotent
@@ -350,7 +350,7 @@ describe Chef::Resource::LoadBalancer do
                 })
                 machines ['test_load_balancer_machine2']
               end
-            }.to match_an_aws_load_balancer('test-load-balancer', driver.elb_client.describe_load_balancers(load_balancer_names: ["test-load-balancer"])[0][0]) { |aws_object|
+            }.to match_an_aws_load_balancer('test-load-balancer') { |aws_object|
               ids = aws_object.instances.map {|i| i.instance_id}
               expect([test_load_balancer_machine2.aws_object.id]).to eq(ids)
             }.and be_idempotent

--- a/spec/integration/load_balancer_spec.rb
+++ b/spec/integration/load_balancer_spec.rb
@@ -311,9 +311,10 @@ describe Chef::Resource::LoadBalancer do
               })
               machines ['test_load_balancer_machine1']
             end
-          }.to create_an_aws_load_balancer('test-load-balancer',
-            :instances => [{id: test_load_balancer_machine1.aws_object.id}]
-          ).and be_idempotent
+          }.to create_an_aws_load_balancer('test-load-balancer') { |aws_object|
+            ids = aws_object.instances.map {|i| i.instance_id}
+            expect([test_load_balancer_machine1.aws_object.id]).to eq(ids)
+          }.and be_idempotent
         end
 
         it "can reference machines by name or id" do
@@ -326,8 +327,7 @@ describe Chef::Resource::LoadBalancer do
               machines ['test_load_balancer_machine1', test_load_balancer_machine2.aws_object.id]
             end
           }.to create_an_aws_load_balancer('test-load-balancer') { |aws_object|
-            instances = aws_object.instances
-            ids = instances.map {|i| i.id}
+            ids = aws_object.instances.map {|i| i.instance_id}
             expect(ids.to_set).to eq([test_load_balancer_machine1.aws_object.id, test_load_balancer_machine2.aws_object.id].to_set)
           }.and be_idempotent
         end
@@ -350,9 +350,10 @@ describe Chef::Resource::LoadBalancer do
                 })
                 machines ['test_load_balancer_machine2']
               end
-            }.to match_an_aws_load_balancer('test-load-balancer',
-              :instances => [{id: test_load_balancer_machine2.aws_object.id}]
-            ).and be_idempotent
+            }.to match_an_aws_load_balancer('test-load-balancer') { |aws_object|
+              ids = aws_object.instances.map {|i| i.instance_id}
+              expect([test_load_balancer_machine2.aws_object.id]).to eq(ids)
+            }.and be_idempotent
           end
         end
       end


### PR DESCRIPTION
@Vasu1105 I think this is ready for merge!

I reverted https://github.com/chef/chef-provisioning-aws/pull/552/commits/a464e484611228789c41b46bef441fe4c2760945 because that change effectively makes the `. create_an_aws_load_balancer` compare the exact same two values.

The first string passed to `create_an_aws_load_balancer` is used to lookup an aws_object based on the [aws_object method](https://github.com/chef/chef-provisioning-aws/blob/f11a11d6f7762e60a653b6794309fe89384f13bc/lib/chef/resource/aws_load_balancer.rb#L18). With the change you had, it was then comparing that object to another object looked up from AWS in the exact same way. So the expected and actual values were the same looked up object from AWS.

I fixed some of the comparison operator's failure to deal with Structs and I think this is ready for review now!