### PR TITLE
[MSYS-705] Adding integration testcases for aws_cache_cluster resource

### DIFF
--- a/lib/chef/provider/aws_cache_cluster.rb
+++ b/lib/chef/provider/aws_cache_cluster.rb
@@ -7,7 +7,8 @@ class Chef::Provider::AwsCacheCluster < Chef::Provisioning::AWSDriver::AWSProvid
 
   def create_aws_object
     converge_by "create ElastiCache cluster #{new_resource.name} in #{region}" do
-      driver.create_cache_cluster(desired_options)
+      cache_cluster = driver.create_cache_cluster(desired_options)
+      wait_for_state(cache_cluster, :available, [], 10, 60)
     end
   end
 

--- a/lib/chef/provisioning/aws_driver/aws_provider.rb
+++ b/lib/chef/provisioning/aws_driver/aws_provider.rb
@@ -15,7 +15,11 @@ class AWSProvider < Chef::Provider::LWRPBase
 
   class StatusTimeoutError < ::Timeout::Error
     def initialize(aws_object, initial_status, expected_status)
-      super("timed out waiting for #{aws_object.id} status to change from #{initial_status.inspect} to #{expected_status.inspect}!")
+      if aws_object.methods.include?(:id)
+        super("timed out waiting for #{aws_object.id} status to change from #{initial_status.inspect} to #{expected_status.inspect}!")
+      else
+        super("timed out waiting for status to change from #{initial_status.inspect} to #{expected_status.inspect}!")
+      end
     end
   end
 
@@ -269,7 +273,12 @@ class AWSProvider < Chef::Provider::LWRPBase
     sleep = opts[:sleep] || 5
 
     Retryable.retryable(:tries => tries, :sleep => sleep) do |retries, exception|
-      action_handler.report_progress "waited #{retries*sleep}/#{tries*sleep}s for <#{aws_object.class}:#{aws_object.id}>##{query_method} state to change to #{expected_responses.inspect}..."
+      if aws_object.methods.include?(:id)
+        action_handler.report_progress "waited #{retries*sleep}/#{tries*sleep}s for <#{aws_object.class}:#{aws_object.id}>##{query_method} state to change to #{expected_responses.inspect}..."
+      else
+        action_handler.report_progress "waited #{retries*sleep}/#{tries*sleep}s for <#{aws_object.class}>##{query_method} state to change to #{expected_responses.inspect}..."
+      end
+
       Chef::Log.debug("Current exception in wait_for is #{exception.inspect}") if exception
       begin
         yield(aws_object) if block_given?

--- a/lib/chef/provisioning/aws_driver/aws_provider.rb
+++ b/lib/chef/provisioning/aws_driver/aws_provider.rb
@@ -15,11 +15,7 @@ class AWSProvider < Chef::Provider::LWRPBase
 
   class StatusTimeoutError < ::Timeout::Error
     def initialize(aws_object, initial_status, expected_status)
-      if aws_object.methods.include?(:id)
-        super("timed out waiting for #{aws_object.id} status to change from #{initial_status.inspect} to #{expected_status.inspect}!")
-      else
-        super("timed out waiting for status to change from #{initial_status.inspect} to #{expected_status.inspect}!")
-      end
+      super("timed out waiting for #{aws_object.id} status to change from #{initial_status.inspect} to #{expected_status.inspect}!")
     end
   end
 
@@ -273,12 +269,7 @@ class AWSProvider < Chef::Provider::LWRPBase
     sleep = opts[:sleep] || 5
 
     Retryable.retryable(:tries => tries, :sleep => sleep) do |retries, exception|
-      if aws_object.methods.include?(:id)
-        action_handler.report_progress "waited #{retries*sleep}/#{tries*sleep}s for <#{aws_object.class}:#{aws_object.id}>##{query_method} state to change to #{expected_responses.inspect}..."
-      else
-        action_handler.report_progress "waited #{retries*sleep}/#{tries*sleep}s for <#{aws_object.class}>##{query_method} state to change to #{expected_responses.inspect}..."
-      end
-
+      action_handler.report_progress "waited #{retries*sleep}/#{tries*sleep}s for <#{aws_object.class}:#{aws_object.id}>##{query_method} state to change to #{expected_responses.inspect}..."
       Chef::Log.debug("Current exception in wait_for is #{exception.inspect}") if exception
       begin
         yield(aws_object) if block_given?

--- a/spec/aws_support/matchers/create_an_aws_object.rb
+++ b/spec/aws_support/matchers/create_an_aws_object.rb
@@ -54,7 +54,7 @@ module AWSSupport
 
         # We get response as a Struct for aws_cache_subnet_group resource.
         # Hence converting it into a hash.
-        aws_object = aws_object.to_hash if resource_name == :aws_cache_subnet_group
+        aws_object = aws_object.to_hash if resource_name == :aws_cache_subnet_group || resource_name == :aws_cache_cluster
 
         # Check existence
         if aws_object.nil?

--- a/spec/integration/aws_cache_cluster_spec.rb
+++ b/spec/integration/aws_cache_cluster_spec.rb
@@ -1,10 +1,25 @@
 require 'spec_helper'
 
-describe Chef::Resource::AwsCacheCluster do
+describe Chef::Resource::AwsCacheCluster, :super_slow do
   extend AWSSupport
 
   when_the_chef_12_server "exists", organization: 'foo', server_scope: :context do
     with_aws "with a VPC, subnet, subnet_group and security_group" do
+      after(:context) do
+        # Cache Cluster takes around 7 minutes to get deleted
+        # and all the dependent resources can be deleted after that only.
+        # Hence waiting for 8 minutes.
+        sleep(480)
+        converge {
+          aws_cache_subnet_group 'test-subnet-group' do
+            action :destroy
+          end
+
+          aws_vpc "test_vpc" do
+            action :purge
+          end
+        }
+      end
 
       it "aws_cache_cluster 'TestRedisCluster' creates a cache cluster" do
         converge {
@@ -12,23 +27,17 @@ describe Chef::Resource::AwsCacheCluster do
             cidr_block '10.0.0.0/24'
             internet_gateway true
           end
-        }
 
-        converge {
           aws_subnet "test_subnet" do
             vpc 'test_vpc'
             cidr_block "10.0.0.0/24"
           end
-        }
 
-        converge {
           aws_cache_subnet_group 'test-subnet-group' do
             description 'Test Subnet Group'
             subnets [ 'test_subnet' ]
           end
-        }
 
-        converge {
           aws_security_group 'test_sg' do
             vpc 'test_vpc'
           end

--- a/spec/integration/aws_cache_cluster_spec.rb
+++ b/spec/integration/aws_cache_cluster_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+describe Chef::Resource::AwsCacheCluster do
+  extend AWSSupport
+
+  when_the_chef_12_server "exists", organization: 'foo', server_scope: :context do
+    with_aws "with a VPC, subnet, subnet_group and security_group" do
+
+      it "aws_cache_cluster 'TestRedisCluster' creates a cache cluster" do
+        converge {
+          aws_vpc "test_vpc" do
+            cidr_block '10.0.0.0/24'
+            internet_gateway true
+          end
+        }
+
+        converge {
+          aws_subnet "test_subnet" do
+            vpc 'test_vpc'
+            cidr_block "10.0.0.0/24"
+          end
+        }
+
+        converge {
+          aws_cache_subnet_group 'test-subnet-group' do
+            description 'Test Subnet Group'
+            subnets [ 'test_subnet' ]
+          end
+        }
+
+        converge {
+          aws_security_group 'test_sg' do
+            vpc 'test_vpc'
+          end
+        }
+
+        expect_recipe {
+          aws_cache_cluster 'TestRedisCluster' do
+            az_mode 'single-az'
+            engine 'redis'
+            engine_version '3.2.6'
+            node_type 'cache.t2.micro'
+            number_nodes 1
+            security_groups 'test_sg'
+            subnet_group_name 'test-subnet-group'
+          end
+        }.to create_an_aws_cache_cluster('TestRedisCluster',
+          cache_cluster_id: "testrediscluster",
+          cache_node_type: "cache.t2.micro",
+          engine: "redis",
+          engine_version: "3.2.6",
+          num_cache_nodes: 1,
+          pending_modified_values: {},
+          cache_security_groups: [],
+          cache_parameter_group:
+            {cache_parameter_group_name: "default.redis3.2", parameter_apply_status: "in-sync", cache_node_ids_to_reboot: []},
+          cache_subnet_group_name: "test-subnet-group"
+          ).and be_idempotent
+      end
+    end
+  end
+end


### PR DESCRIPTION
`destroy` method is called immediately after the integration test finishes for any resource. `aws_cache_cluster` resource takes around 10 minutes to become available and it can't be deleted till it's not in available state.
So this PR is adding `wait_for_cache_cluster_state` method for `aws_cache_cluster` resource, so that the integration testcase can run successfully.

Please note that this adds a delay of 10 minutes in the integration testcases and also while running any recipe of ` aws_cache_cluster` resource.