### PR TITLE
Fix for bootstrap_options included in knife.rb

### DIFF
--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -913,7 +913,7 @@ EOD
     end
 
     def bootstrap_options_for(action_handler, machine_spec, machine_options)
-      bootstrap_options = (machine_options[:bootstrap_options] || {}).dup
+      bootstrap_options = deep_symbolize_keys(machine_options[:bootstrap_options])
       # These are hardcoded for now - only 1 machine at a time
       bootstrap_options[:min_count] = bootstrap_options[:max_count] = 1
       bootstrap_options[:instance_type] ||= default_instance_type


### PR DESCRIPTION
This bug was introduced in v2.2.0 here:
https://github.com/chef/chef-provisioning-aws/compare/v2.1.0...v2.2.0#diff-0410aad4b9403c10f07fbeb410833ef5L852