### PR TITLE
Test on Ruby 2.4.3 and resolve Fixnum deprecation warning

### DIFF
--- a/lib/chef/resource/aws_route53_record_set.rb
+++ b/lib/chef/resource/aws_route53_record_set.rb
@@ -45,7 +45,7 @@ class Chef::Resource::AwsRoute53RecordSet < Chef::Provisioning::AWSDriver::Super
 
   attribute :type, equal_to: %w(SOA A TXT NS CNAME MX PTR SRV SPF AAAA), required: true
 
-  attribute :ttl, kind_of: Fixnum, required: true
+  attribute :ttl, kind_of: Integer, required: true
 
   attribute :resource_records, kind_of: Array, required: true
 


### PR DESCRIPTION
This was showing up on our ChefDK testers

Signed-off-by: Tim Smith <tsmith@chef.io>