### PR TITLE
Allow arbitarily Long resource IDs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.1
+  - 2.4.3
 env:
   global:
   # encrypted with `travis encrypt "AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=..."`

--- a/lib/chef/provider/aws_route_table.rb
+++ b/lib/chef/provider/aws_route_table.rb
@@ -139,15 +139,15 @@ class Chef::Provider::AwsRouteTable < Chef::Provisioning::AWSDriver::AWSProvider
         raise "VPC #{new_resource.vpc} (#{vpc.id}) does not have an internet gateway to route to! Use `internet_gateway true` on the VPC itself to create one."
       end
       route_target = { internet_gateway: vpc.internet_gateways.first.id }
-    when /^igw-[A-Fa-f0-9]{8}$/, Chef::Resource::AwsInternetGateway, ::Aws::EC2::InternetGateway
+    when /^igw-[A-Fa-f0-9]+$/, Chef::Resource::AwsInternetGateway, ::Aws::EC2::InternetGateway
       route_target = { internet_gateway: route_target }
-    when /^nat-[A-Fa-f0-9]{17}$/, Chef::Resource::AwsNatGateway, ::Aws::EC2::NatGateway
+    when /^nat-[A-Fa-f0-9]+$/, Chef::Resource::AwsNatGateway, ::Aws::EC2::NatGateway
       route_target = { nat_gateway: route_target }
-    when /^eni-[A-Fa-f0-9]{8}$/, Chef::Resource::AwsNetworkInterface, ::Aws::EC2::NetworkInterface
+    when /^eni-[A-Fa-f0-9]+$/, Chef::Resource::AwsNetworkInterface, ::Aws::EC2::NetworkInterface
       route_target = { network_interface: route_target }
-    when /^pcx-[A-Fa-f0-9]{8}$/, Chef::Resource::AwsVpcPeeringConnection, ::Aws::EC2::VpcPeeringConnection
+    when /^pcx-[A-Fa-f0-9]+$/, Chef::Resource::AwsVpcPeeringConnection, ::Aws::EC2::VpcPeeringConnection
       route_target = { vpc_peering_connection: route_target }
-    when /^vgw-[A-Fa-f0-9]{8}$/
+    when /^vgw-[A-Fa-f0-9]+$/
       route_target = { virtual_private_gateway: route_target }
     when String, Chef::Resource::AwsInstance
       route_target = { instance: route_target }

--- a/lib/chef/provider/aws_security_group.rb
+++ b/lib/chef/provider/aws_security_group.rb
@@ -444,7 +444,7 @@ class Chef::Provider::AwsSecurityGroup < Chef::Provisioning::AWSDriver::AWSProvi
       end
 
     # If a load balancer is specified, grab it and then get its automatic security group
-    when /^elb-[a-fA-F0-9]{8}$/, Aws::ElasticLoadBalancing::Types::LoadBalancerDescription, Chef::Resource::AwsLoadBalancer
+    when /^elb-[a-fA-F0-9]+$/, Aws::ElasticLoadBalancing::Types::LoadBalancerDescription, Chef::Resource::AwsLoadBalancer
       lb=actor_spec
       if lb.class != Aws::ElasticLoadBalancing::Types::LoadBalancerDescription
         lb = Chef::Resource::AwsLoadBalancer.get_aws_object(actor_spec, resource: new_resource)
@@ -459,7 +459,7 @@ class Chef::Provider::AwsSecurityGroup < Chef::Provisioning::AWSDriver::AWSProvi
       end
 
     # If a security group is specified, grab it
-    when /^sg-[a-fA-F0-9]{8}$/, ::Aws::EC2::SecurityGroup, Chef::Resource::AwsSecurityGroup
+    when /^sg-[a-fA-F0-9]+$/, ::Aws::EC2::SecurityGroup, Chef::Resource::AwsSecurityGroup
       Chef::Resource::AwsSecurityGroup.get_aws_object(actor_spec, resource: new_resource)
 
     # If an IP addresses / CIDR are passed, return it verbatim; otherwise, assume it's the

--- a/lib/chef/provisioning/aws_driver/driver.rb
+++ b/lib/chef/provisioning/aws_driver/driver.rb
@@ -69,7 +69,7 @@ class Provider
     # We override this so we can specify a machine name as `i-123456`
     # This is totally a hack until we move away from base resources
     def get_machine_spec!(machine_name)
-      if machine_name =~ /^i-[0-9a-f]{8}/
+      if machine_name =~ /^i-[0-9a-f]+/
         Struct.new(:name, :reference).new(machine_name, {'instance_id' => machine_name})
       else
         Chef::Log.debug "Getting machine spec for #{machine_name}"

--- a/lib/chef/resource/aws_dhcp_options.rb
+++ b/lib/chef/resource/aws_dhcp_options.rb
@@ -48,7 +48,7 @@ class Chef::Resource::AwsDhcpOptions < Chef::Provisioning::AWSDriver::AWSResourc
   attribute :netbios_node_type, kind_of: Integer
 
   attribute :dhcp_options_id, kind_of: String, aws_id_attribute: true, default: lazy {
-    name =~ /^dopt-[a-f0-9]{8}$/ ? name : nil
+    name =~ /^dopt-[a-f0-9]+$/ ? name : nil
   }
 
   def aws_object

--- a/lib/chef/resource/aws_ebs_volume.rb
+++ b/lib/chef/resource/aws_ebs_volume.rb
@@ -20,7 +20,7 @@ class Chef::Resource::AwsEbsVolume < Chef::Provisioning::AWSDriver::AWSResourceW
   attribute :device,            kind_of: String
 
   attribute :volume_id,         kind_of: String, aws_id_attribute: true, default: lazy {
-    name =~ /^vol-(?:[a-f0-9]{8}|[a-f0-9]{17})$/ ? name : nil
+    name =~ /^vol-[a-f0-9]+$/ ? name : nil
   }
 
   def aws_object

--- a/lib/chef/resource/aws_image.rb
+++ b/lib/chef/resource/aws_image.rb
@@ -11,7 +11,7 @@ class Chef::Resource::AwsImage < Chef::Provisioning::AWSDriver::AWSResourceWithE
   attribute :name, kind_of: String, name_attribute: true
 
   attribute :image_id, kind_of: String, aws_id_attribute: true, default: lazy {
-    name =~ /^ami-[a-f0-9]{8}$/ ? name : nil
+    name =~ /^ami-[a-f0-9]+$/ ? name : nil
   }
 
   def aws_object

--- a/lib/chef/resource/aws_instance.rb
+++ b/lib/chef/resource/aws_instance.rb
@@ -13,7 +13,7 @@ class Chef::Resource::AwsInstance < Chef::Provisioning::AWSDriver::AWSResourceWi
   attribute :name, kind_of: String, name_attribute: true
 
   attribute :instance_id, kind_of: String, aws_id_attribute: true, default: lazy {
-    name =~ /^i-(?:[a-f0-9]{8}|[a-f0-9]{17})$/ ? name : nil
+    name =~ /^i-[a-f0-9]+$/ ? name : nil
   }
 
   def aws_object

--- a/lib/chef/resource/aws_internet_gateway.rb
+++ b/lib/chef/resource/aws_internet_gateway.rb
@@ -37,7 +37,7 @@ class Chef::Resource::AwsInternetGateway < Chef::Provisioning::AWSDriver::AWSRes
   attribute :vpc, kind_of: [ String, AwsVpc, ::Aws::EC2::Vpc ]
 
   attribute :internet_gateway_id, kind_of: String, aws_id_attribute: true, default: lazy {
-    name =~ /^igw-[a-f0-9]{8}$/ ? name : nil
+    name =~ /^igw-[a-f0-9]+$/ ? name : nil
   }
 
   def aws_object

--- a/lib/chef/resource/aws_load_balancer.rb
+++ b/lib/chef/resource/aws_load_balancer.rb
@@ -9,7 +9,7 @@ class Chef::Resource::AwsLoadBalancer < Chef::Provisioning::AWSDriver::AWSResour
   attribute :name, kind_of: String,  name_attribute: true
 
   attribute :load_balancer_id, kind_of: String, aws_id_attribute: true, default: lazy {
-    name =~ /^elb-[a-f0-9]{8}$/ ? name : nil
+    name =~ /^elb-[a-f0-9]+$/ ? name : nil
   }
 
   def aws_object

--- a/lib/chef/resource/aws_nat_gateway.rb
+++ b/lib/chef/resource/aws_nat_gateway.rb
@@ -87,7 +87,7 @@ class Chef::Resource::AwsNatGateway < Chef::Provisioning::AWSDriver::AWSResource
   attribute :eip_address, kind_of: [ String, ::Aws::OpsWorks::Types::ElasticIp, AwsEipAddress, nil ], default: nil
 
   attribute :nat_gateway_id, kind_of: String, aws_id_attribute: true, default: lazy {
-    name =~ /^nat-[A-Fa-f0-9]{17}$/ ? name : nil
+    name =~ /^nat-[A-Fa-f0-9]+$/ ? name : nil
   }
 
   def aws_object

--- a/lib/chef/resource/aws_network_acl.rb
+++ b/lib/chef/resource/aws_network_acl.rb
@@ -45,7 +45,7 @@ class Chef::Resource::AwsNetworkAcl < Chef::Provisioning::AWSDriver::AWSResource
             kind_of: String,
             aws_id_attribute: true,
             default: lazy {
-              name =~ /^acl-[a-f0-9]{8}$/ ? name : nil
+              name =~ /^acl-[a-f0-9]+$/ ? name : nil
             }
 
   def aws_object

--- a/lib/chef/resource/aws_network_interface.rb
+++ b/lib/chef/resource/aws_network_interface.rb
@@ -10,7 +10,7 @@ class Chef::Resource::AwsNetworkInterface < Chef::Provisioning::AWSDriver::AWSRe
   attribute :name,                   kind_of: String, name_attribute: true
 
   attribute :network_interface_id,   kind_of: String, aws_id_attribute: true, default: lazy {
-    name =~ /^eni-[a-f0-9]{8}$/ ? name : nil
+    name =~ /^eni-[a-f0-9]+$/ ? name : nil
   }
 
   attribute :subnet,                 kind_of: [ String, ::Aws::EC2::Subnet, AwsSubnet ]

--- a/lib/chef/resource/aws_route_table.rb
+++ b/lib/chef/resource/aws_route_table.rb
@@ -93,7 +93,7 @@ class Chef::Resource::AwsRouteTable < Chef::Provisioning::AWSDriver::AWSResource
             coerce: proc { |v| [v].flatten }
 
   attribute :route_table_id, kind_of: String, aws_id_attribute: true, default: lazy {
-    name =~ /^rtb-[a-f0-9]{8}$/ ? name : nil
+    name =~ /^rtb-[a-f0-9]+$/ ? name : nil
   }
 
   def aws_object

--- a/lib/chef/resource/aws_security_group.rb
+++ b/lib/chef/resource/aws_security_group.rb
@@ -50,7 +50,7 @@ class Chef::Resource::AwsSecurityGroup < Chef::Provisioning::AWSDriver::AWSResou
   attribute :outbound_rules, kind_of: [ Array, Hash ]
 
   attribute :security_group_id, kind_of: String, aws_id_attribute: true, default: lazy {
-    name =~ /^sg-[a-f0-9]{8}$/ ? name : nil
+    name =~ /^sg-[a-f0-9]+$/ ? name : nil
   }
 
   def aws_object

--- a/lib/chef/resource/aws_subnet.rb
+++ b/lib/chef/resource/aws_subnet.rb
@@ -87,7 +87,7 @@ class Chef::Resource::AwsSubnet < Chef::Provisioning::AWSDriver::AWSResourceWith
   attribute :network_acl, kind_of: [ String, AwsNetworkAcl, ::Aws::EC2::NetworkAcl ]
 
   attribute :subnet_id, kind_of: String, aws_id_attribute: true, default: lazy {
-    name =~ /^subnet-[a-f0-9]{8}$/ ? name : nil
+    name =~ /^subnet-[a-f0-9]+$/ ? name : nil
   }
 
   def aws_object

--- a/lib/chef/resource/aws_vpc.rb
+++ b/lib/chef/resource/aws_vpc.rb
@@ -128,7 +128,7 @@ class Chef::Resource::AwsVpc < Chef::Provisioning::AWSDriver::AWSResourceWithEnt
   attribute :enable_dns_hostnames, equal_to: [ true, false ]
 
   attribute :vpc_id, kind_of: String, aws_id_attribute: true, default: lazy {
-    name =~ /^vpc-[a-f0-9]{8}$/ ? name : nil
+    name =~ /^vpc-[a-f0-9]+$/ ? name : nil
   }
 
   def aws_object

--- a/lib/chef/resource/aws_vpc_peering_connection.rb
+++ b/lib/chef/resource/aws_vpc_peering_connection.rb
@@ -55,7 +55,7 @@ class Chef::Resource::AwsVpcPeeringConnection < Chef::Provisioning::AWSDriver::A
   attribute :peer_owner_id, kind_of: String
 
   attribute :vpc_peering_connection_id, kind_of: String, aws_id_attribute: true, default: lazy {
-    name =~ /^pcx-[a-f0-9]{8}$/ ? name : nil
+    name =~ /^pcx-[a-f0-9]+$/ ? name : nil
   }
 
   def aws_object


### PR DESCRIPTION
AWS is changing their length again, and will cotninue to do so.  lets just stop enforcing this length...