### PR TITLE
replace driver with self.driver in get_driver_and_id

### DIFF
--- a/lib/chef/provisioning/aws_driver/aws_resource_with_entry.rb
+++ b/lib/chef/provisioning/aws_driver/aws_resource_with_entry.rb
@@ -81,7 +81,7 @@ class Chef::Provisioning::AWSDriver::AWSResourceWithEntry < Chef::Provisioning::
     driver, id, entry = get_id_from_managed_entry
     # If the value isn't already stored, look up the user-specified public_ip
     unless id
-      driver = driver
+      driver = self.driver
       id = public_send(self.class.aws_id_attribute)
     end
     [driver, id]


### PR DESCRIPTION
this makes it work with latest chef.  to be honest, i am unsure how this ever worked - it should not have.  it relied on weird ruby scoping that does not work anymore